### PR TITLE
Add GitHub Actions CI to Build/Release Spec

### DIFF
--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -1,0 +1,40 @@
+name:
+
+on: push
+
+jobs:
+  markdown-to-pdf:
+    runs-on: ubuntu-18.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - run: mkdir build
+      - name: "Markdown -> [pandoc] -> LaTeX "
+        uses: docker://pandoc/core:2.17
+        with:
+          args: >- # allows you to break string into multiple lines
+            spec.md
+            --template include/spec-template.tex
+            --syntax-definition include/firrtl.xml
+            --syntax-definition include/ebnf.xml
+            -r markdown+table_captions+inline_code_attributes+gfm_auto_identifiers
+            --filter pandoc-crossref
+            -o build/spec.tex
+      - name: "LaTeX -> [TeX Live] -> PDF"
+        uses: xu-cheng/texlive-action/small@v1
+        with:
+          run: (cd build && latexmk -pdf spec.tex)
+      - name: "Upload build directory"
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: build
+          retention-days: 1
+      - name: "Create Release if Tagged"
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          fail_on_unmatched_files: true
+          files: build/spec.pdf


### PR DESCRIPTION
Add a GitHub Actions CI pipeline that builds the PDF version of the spec
from the source Markdown.  (This uses a combination of a Pandoc docker
image followed by a LaTeX docker image to temporarily work around a bug
in the Pandoc docker image [1].)  The results of the build are uploaded
as a GitHub Actions artifact with an expiration of one day.  This is
done to enable users to check the output of what they built (or to debug
problems where the local installation of pandoc + LaTeX may differ from
what runs in CI).  Finally, if the commit is tagged then a new release
is created where the built PDF spec is added as an additional file.

Fixes #2.

[1]: https://github.com/pandoc/dockerfiles/issues/167

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>