### PR TITLE
cover: goal is 'en and pred', not 'en → pred'

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1553,7 +1553,7 @@ assume(clk, pred, en, "X equals Y when Z is valid") : optional_name
 
 The cover statement verifies that the predicate is true on the rising edge of
 some clock cycle when the enable is true. In other words, it directs the model
-checker to find some way to make enable implies predicate true at some time
+checker to find some way to make both enable and predicate true at some time
 step.
 
 ``` firrtl


### PR DESCRIPTION
'en → pred' is vacuously true when 'en' is false,
we want model checker to make pred true when en is true
(not find a way to make 'en' false, for example).