### PR TITLE
Bit-index support (subword assignment)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ IMG_EPSS=$(foreach dotfile,$(IMG_SRCS),build/img/$(patsubst %.dot,%.eps,$(lastwo
 
 images: $(IMG_EPSS)
 
+build/img:
+	mkdir -p build/img
+
 build/spec.pdf: spec.md include/spec-template.tex include/firrtl.xml include/ebnf.xml $(IMG_EPSS) | build/
 	pandoc $< --template include/spec-template.tex --syntax-definition include/firrtl.xml --syntax-definition include/ebnf.xml -r markdown+table_captions+inline_code_attributes+gfm_auto_identifiers --filter pandoc-crossref -o $@
 

--- a/spec.md
+++ b/spec.md
@@ -1798,6 +1798,26 @@ module MyModule :
    out[4] <= in
 ```
 
+## Bit-indices
+
+The bit-index expression statically refers, by index, to a particular bit of an
+expression with an integer type (`UInt` or `SInt`). The index must be a
+non-negative integer and cannot be equal to or exceed the width of the integer
+it indexes. The bit-index must be connected to a value of type `UInt<1>` and
+can only be used as a sink. In order to get a particular bit of an integer
+expression as a source, use the `bits` primitive operation (see
+[@sec:bit-extraction-operation]).
+
+The following example connects the `in`{.firrtl} port to the fifth bit
+of the `out`{.firrtl} port.
+
+``` firrtl
+module MyModule :
+   input in: UInt<1>
+   output out: UInt<10>
+   out[4] <= in
+```
+
 ## Sub-accesses
 
 The sub-access expression dynamically refers to a sub-element of a vector-typed
@@ -2340,6 +2360,8 @@ wire or register is duplex.
 The flow of a sub-index or sub-access expression is the flow of the vector-typed
 expression it indexes or accesses.
 
+The flow of a bit-index is sink.
+
 The flow of a sub-field expression depends upon the orientation of the field. If
 the field is not flipped, its flow is the same flow as the bundle-typed
 expression it selects its field from. If the field is flipped, then its flow is
@@ -2603,6 +2625,8 @@ following restrictions:
 - All components must be declared with a ground type.
 
 - The partial connect statement is not used.
+
+- The bit-index expression is not used
 
 The first three restrictions follow from the fact that any LoFIRRTL circuit is
 also a legal MidFIRRTL circuit. The additional restrictions give LoFIRRTL a

--- a/spec.md
+++ b/spec.md
@@ -1801,12 +1801,12 @@ module MyModule :
 ## Bit-indices
 
 The bit-index expression statically refers, by index, to a particular bit of an
-expression with an integer type (`UInt` or `SInt`). The index must be a
-non-negative integer and cannot be equal to or exceed the width of the integer
-it indexes. The bit-index must be connected to a value of type `UInt<1>` and
-can only be used as a sink. In order to get a particular bit of an integer
-expression as a source, use the `bits` primitive operation (see
-[@sec:bit-extraction-operation]).
+expression with an integer type (`UInt`{.firrtl} or `SInt`{.firrtl}). The index
+must be a non-negative integer and cannot be equal to or exceed the width of
+the integer it indexes. The bit-index must be connected to a value of type
+`UInt<1>`{.firrtl} and can only be used as a sink. In order to get a particular
+bit of an integer expression as a source, use the `bits`{.firrtl} primitive
+operation (see [@sec:bit-extraction-operation]).
 
 The following example connects the `in`{.firrtl} port to the fifth bit
 of the `out`{.firrtl} port.


### PR DESCRIPTION
This is a proposal for adding subword assignment support to FIRRTL. The full proposal can be viewed here: [subword.pdf](https://github.com/chipsalliance/firrtl-spec/files/9088966/subword.pdf).

As a summary, this change would allow indexing expressions of type `UInt` or `SInt` to assign specific bits. This proposal only covers single-bit subword assignment at a static index. The "bit-index" expression must be used as a sink. For example, this would allow:

```firrtl
input x : UInt<4>
input y : UInt<1>
output z : UInt<4>

z <= x
z[0] <= y
z[1] <= bits(z, 0, 0)
```

The proposal gives an algorithm for transforming subword assignment to existing FIRRTL by rewriting using vectors (`UInt<1>[n]`). I have a prototype CIRCT implementation at https://github.com/zyedidia/circt/tree/subword-assignment that performs the transformation in the proposal.

Let me know what you think!

(I also included a small fix for the makefile since typing `make` on a fresh clone didn't work).