### PR TITLE
Add a versions Table, define versioning scheme, and bump version to 1.0.0

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4,7 +4,7 @@ author:
 title: Specification for the FIRRTL Language
 date: \today
 # Custom options added to the customized template
-version: 0.4.1
+version: 1.0.0
 # Options passed to the document class
 classoption:
 - 12pt

--- a/spec.md
+++ b/spec.md
@@ -52,6 +52,11 @@ lastDelim: ", and"
     due to their widespread use in Chisel and the SFC: Annotations, Targets,
     Asynchronous Reset,  Abstract Reset
   - Minor typo corrections and prose clarifications.
+* 0.3.1
+  - Clarify analog usage in registers
+  - Rework authorship as "The FIRRTL Specification Contributors"
+  - Add version information as subtitle
+  - Formatting fixes
 * 0.3.0 Document moved to Markdown
 
 # Introduction

--- a/spec.md
+++ b/spec.md
@@ -45,7 +45,7 @@ lastDelim: ", and"
 
 # Versions
 
-- 0.4.1 Added missing information about AsyncReset, Reset, Targets and Annotations
+- 0.4.1 Clarify the versioning scheme of this specification.
 - 0.4.0 Doc moved to Markdown
 
 # Introduction
@@ -2900,3 +2900,22 @@ circuit = "circuit" , id , ":" , [ info ] , newline , indent ,
             { module | extmodule } ,
           dedent ;
 ```
+
+
+# Versioning Scheme of this Document
+
+This is the versioning scheme that applies 0.4.0 and later.
+
+The versioning scheme applies [Semantic Versioning 2.0.0](https://semver.org/#semantic-versioning-200).
+
+Specifically, 
+
+The PATCH digit is bumped upon release which only includes non-functional changes, such as grammar edits,
+further examples, and clarifications.
+
+The MINOR digit is bumped for feature additions to the spec.
+
+The MAJOR digit is bumped for backwards-incompatible changes such as features being removed from the spec or changing their interpretation.
+
+In other words, Any `.fir` file that was compliant with `x.y.z` will be compliant with `x.Y.Z`, where `Y >= y`, z and Z can be any number.
+

--- a/spec.md
+++ b/spec.md
@@ -46,7 +46,12 @@ lastDelim: ", and"
 # Revision History
 
 - 1.0.0 Clarify the versioning scheme of this specification.
-- 0.4.0 Doc moved to Markdown
+- 0.4.0
+  - Add documentation for undocumented features of
+the Scala-based FIRRTL Compiler (SFC) that are de facto a part of the
+FIRRTL specification due to their widespread use in Chisel and the SFC:  Annotations, Targets, Asynchronous Reset,  Abstract Reset
+  - There are also minor typo corrections and prose clarifications.
+- 0.3.0 Doc moved to Markdown
 
 # Introduction
 

--- a/spec.md
+++ b/spec.md
@@ -2932,6 +2932,6 @@ The MAJOR digit is bumped for backwards-incompatible changes such as features
 being removed from the spec, changing their interpretation, or new required
 features being added to the specification.
 
-In other words, Any `.fir` file that was compliant with `x.y.z` will be compliant
+In other words, any `.fir` file that was compliant with `x.y.z` will be compliant
 with `x.Y.Z`, where `Y >= y`, `z` and `Z` can be any number.
 

--- a/spec.md
+++ b/spec.md
@@ -45,13 +45,14 @@ lastDelim: ", and"
 
 # Revision History
 
-- 1.0.0 Clarify the versioning scheme of this specification.
-- 0.4.0
-  - Add documentation for undocumented features of
-the Scala-based FIRRTL Compiler (SFC) that are de facto a part of the
-FIRRTL specification due to their widespread use in Chisel and the SFC:  Annotations, Targets, Asynchronous Reset,  Abstract Reset
-  - There are also minor typo corrections and prose clarifications.
-- 0.3.0 Doc moved to Markdown
+* 1.0.0 Document the versioning scheme of this specification.
+* 0.4.0
+  - Add documentation for undocumented features of the Scala-based
+    FIRRTL Compiler (SFC) that are de facto a part of the FIRRTL specification
+    due to their widespread use in Chisel and the SFC: Annotations, Targets,
+    Asynchronous Reset,  Abstract Reset
+  - Minor typo corrections and prose clarifications.
+* 0.3.0 Document moved to Markdown
 
 # Introduction
 

--- a/spec.md
+++ b/spec.md
@@ -2915,7 +2915,7 @@ further examples, and clarifications.
 
 The MINOR digit is bumped for feature additions to the spec.
 
-The MAJOR digit is bumped for backwards-incompatible changes such as features being removed from the spec or changing their interpretation.
+The MAJOR digit is bumped for backwards-incompatible changes such as features being removed from the spec, changing their interpretation, or new required features being added to the specification.
 
 In other words, Any `.fir` file that was compliant with `x.y.z` will be compliant with `x.Y.Z`, where `Y >= y`, `z` and `Z` can be any number.
 

--- a/spec.md
+++ b/spec.md
@@ -2917,5 +2917,5 @@ The MINOR digit is bumped for feature additions to the spec.
 
 The MAJOR digit is bumped for backwards-incompatible changes such as features being removed from the spec or changing their interpretation.
 
-In other words, Any `.fir` file that was compliant with `x.y.z` will be compliant with `x.Y.Z`, where `Y >= y`, z and Z can be any number.
+In other words, Any `.fir` file that was compliant with `x.y.z` will be compliant with `x.Y.Z`, where `Y >= y`, `z` and `Z` can be any number.
 

--- a/spec.md
+++ b/spec.md
@@ -4,7 +4,7 @@ author:
 title: Specification for the FIRRTL Language
 date: \today
 # Custom options added to the customized template
-version: 0.4.0
+version: 0.4.1
 # Options passed to the document class
 classoption:
 - 12pt
@@ -42,6 +42,11 @@ secPrefix:
 # This 'lastDelim' option does not work...
 lastDelim: ", and"
 ---
+
+# Versions
+
+- 0.4.1 Added missing information about AsyncReset, Reset, Targets and Annotations
+- 0.4.0 Doc moved to Markdown
 
 # Introduction
 

--- a/spec.md
+++ b/spec.md
@@ -2916,7 +2916,7 @@ circuit = "circuit" , id , ":" , [ info ] , newline , indent ,
 
 # Versioning Scheme of this Document
 
-This is the versioning scheme that applies 1.0.0 and later.
+This is the versioning scheme that applies to version 1.0.0 and later.
 
 The versioning scheme complies with
 [Semantic Versioning 2.0.0](https://semver.org/#semantic-versioning-200).

--- a/spec.md
+++ b/spec.md
@@ -45,7 +45,7 @@ lastDelim: ", and"
 
 # Versions
 
-- 0.4.1 Clarify the versioning scheme of this specification.
+- 1.0.0 Clarify the versioning scheme of this specification.
 - 0.4.0 Doc moved to Markdown
 
 # Introduction

--- a/spec.md
+++ b/spec.md
@@ -172,6 +172,7 @@ contributors is below:
 - [`@grebe`](https://github.com/grebe)
 - [`@jackkoenig`](https://github.com/jackkoenig)
 - [`@jared-barocsi`](https://github.com/jared-barocsi)
+- [`@mwachs5`](https://github.com/mwachs5)
 - [`@richardxia`](https://github.com/richardxia)
 - [`@seldridge`](https://github.com/seldridge)
 - [`@sequencer`](https://github.com/sequencer)

--- a/spec.md
+++ b/spec.md
@@ -2904,7 +2904,7 @@ circuit = "circuit" , id , ":" , [ info ] , newline , indent ,
 
 # Versioning Scheme of this Document
 
-This is the versioning scheme that applies 0.4.0 and later.
+This is the versioning scheme that applies 1.0.0 and later.
 
 The versioning scheme applies [Semantic Versioning 2.0.0](https://semver.org/#semantic-versioning-200).
 

--- a/spec.md
+++ b/spec.md
@@ -2917,7 +2917,7 @@ circuit = "circuit" , id , ":" , [ info ] , newline , indent ,
 
 This is the versioning scheme that applies 1.0.0 and later.
 
-The versioning scheme applies
+The versioning scheme complies with
 [Semantic Versioning 2.0.0](https://semver.org/#semantic-versioning-200).
 
 Specifically, 

--- a/spec.md
+++ b/spec.md
@@ -2912,16 +2912,20 @@ circuit = "circuit" , id , ":" , [ info ] , newline , indent ,
 
 This is the versioning scheme that applies 1.0.0 and later.
 
-The versioning scheme applies [Semantic Versioning 2.0.0](https://semver.org/#semantic-versioning-200).
+The versioning scheme applies
+[Semantic Versioning 2.0.0](https://semver.org/#semantic-versioning-200).
 
 Specifically, 
 
-The PATCH digit is bumped upon release which only includes non-functional changes, such as grammar edits,
-further examples, and clarifications.
+The PATCH digit is bumped upon release which only includes non-functional changes,
+such as grammar edits, further examples, and clarifications.
 
 The MINOR digit is bumped for feature additions to the spec.
 
-The MAJOR digit is bumped for backwards-incompatible changes such as features being removed from the spec, changing their interpretation, or new required features being added to the specification.
+The MAJOR digit is bumped for backwards-incompatible changes such as features
+being removed from the spec, changing their interpretation, or new required
+features being added to the specification.
 
-In other words, Any `.fir` file that was compliant with `x.y.z` will be compliant with `x.Y.Z`, where `Y >= y`, `z` and `Z` can be any number.
+In other words, Any `.fir` file that was compliant with `x.y.z` will be compliant
+with `x.Y.Z`, where `Y >= y`, `z` and `Z` can be any number.
 

--- a/spec.md
+++ b/spec.md
@@ -43,7 +43,7 @@ secPrefix:
 lastDelim: ", and"
 ---
 
-# Versions
+# Revision History
 
 - 1.0.0 Clarify the versioning scheme of this specification.
 - 0.4.0 Doc moved to Markdown


### PR DESCRIPTION
~Since 0.4.0 we added a lot of information missing from the spec so seems we should bump and re-release the doc.~ The 0.4.0 version bump post-dated adding the missing stuff. So changing this PR to  say something about the versioning scheme of this document and when to bump each version.