### PR TITLE
Add an optional enable signal to registers.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -901,10 +901,32 @@ reg myreg: SInt, myclock with: (reset => (myreset, myinit))
 ; ...
 ```
 
-Note that the clock signal for a register must be of type `clock`{.firrtl},
-the reset signal must be a `Reset`{.firrtl}, `UInt<1>`{.firrtl}, or
-`AsyncReset`{.firrtl}, and the type of initialization value must be equivalent
-to the declared type of the register (see [@sec:type-equivalence] for details).
+Optionally, a register can be
+declared with an enable signal. In the following example,
+`myreg`{.firrtl} is written the value `myval`{.firrtl} when the signal
+`myen`{.firrtl} is high.  Enable must
+be a value of type UInt<1>.
+
+``` firrtl
+wire myclock: Clock
+wire myen: UInt<1>
+wire myval: SInt
+reg myreg: SInt, myclock with: (enable => myen)
+myreg <= myval
+; ...
+```
+
+When both reset and enable are present, reset shall be listed first, separated
+by a comman from enable.  Reset of the register is unaffected by the enable 
+signal, depending only on reset signal.
+```
+reg myreg: SInt, myclock with: (reset => (myreset, myinit), enable => myen)
+```
+
+
+Note that the clock signal for a register must be of type `clock`{.firrtl}, the
+reset signal must be a single bit `UInt`{.firrtl}, and the type of
+initialization value must match the declared type of the register.
 
 ## Invalidates
 

--- a/spec.md
+++ b/spec.md
@@ -880,10 +880,12 @@ A register is a named stateful circuit component.  Reads from a register return
 the value of the element, writes are not visible until after the positive edges 
 of the register's clock port.
 
+The clock signal for a register must be of type `Clock`{.firrtl}.  The type of a 
+register must be a passive type (see [@sec:passive-types]).
+
 The following example demonstrates instantiating a register with the given name
 `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
-`myclock`{.firrtl}.  The clock signal for a register must be of type 
-`Clock`{.firrtl}.
+`myclock`{.firrtl}.
 
 ``` firrtl
 wire myclock: Clock
@@ -899,9 +901,9 @@ initialization  value must be equivalent to the declared type of the register
 (see [@sec:type-equivalence] for details). The behavior of the register depends 
 on the type of the reset signal.  `AsyncReset`.{firrtl} will immediately change 
 the value of the register, while other types will not change the value of the 
-register until the next positive edge of the clock signal.  In the following 
-example, `myreg`{.firrtl} is assigned the value `myinit`{.firrtl} when the 
-signal `myreset`{.firrtl} is high.  
+register until the next positive edge of the clock signal (see [@sec:reset-type]).
+In the following example, `myreg`{.firrtl} is assigned the value 
+`myinit`{.firrtl} when the signal `myreset`{.firrtl} is high.  
 ``` firrtl
 wire myclock: Clock
 wire myreset: UInt<1>
@@ -2907,7 +2909,12 @@ memory = "mem" , id , ":" , [ info ] , newline , indent ,
 (* Statements *)
 statement = "wire" , id , ":" , type , [ info ]
           | "reg" , id , ":" , type , expr ,
-            [ "(with: {reset => (" , expr , "," , expr ")})" ] , [ info ]
+            [ "(with: {"
+              ( "reset => (" , expr , "," , expr ")"
+              | "enable => (" , expr , ")"
+              | "reset => (" , expr , "," , expr "), enable => (" , expr , ")"
+              ) , "})" ,
+            [ info ]
           | memory
           | "inst" , id , "of" , id , [ info ]
           | "node" , id , "=" , expr , [ info ]

--- a/spec.md
+++ b/spec.md
@@ -910,12 +910,13 @@ reg myreg: SInt, myclock with: (reset => (myreset, myinit))
 ; ...
 ```
 
-Optionally, a register can be declared with an enable signal. Enable gates 
-writes to a register, such that they only take effect if the enable signal is 
-high.  Functionally this is equivalent to a register written by a mux of the old 
-value and the new value, controlled by the enable signal.  In the following 
+Optionally, a register can be declared with an enable signal. The enable signal 
+gates writes to a register, such that they only take effect if the enable signal 
+is high.  Functionally this is equivalent to a register written by a mux of the 
+old value and the new value, controlled by the enable signal.  In the following 
 example, `myreg`{.firrtl} is written the value `myval`{.firrtl} when the signal 
-`myen`{.firrtl} is high.  Enable must be a value of type `UInt<1>`{.firrtl}.
+`myen`{.firrtl} is high.  The enable signal must be a value of type 
+`UInt<1>`{.firrtl}.
 
 ``` firrtl
 wire myclock: Clock

--- a/spec.md
+++ b/spec.md
@@ -880,7 +880,8 @@ A register is a named stateful circuit component.
 
 The following example demonstrates instantiating a register with the given name
 `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
-`myclock`{.firrtl}.
+`myclock`{.firrtl}.  The clock signal for a register must be of type 
+`clock`{.firrtl}.
 
 ``` firrtl
 wire myclock: Clock
@@ -891,7 +892,10 @@ reg myreg: SInt, myclock
 Optionally, for the purposes of circuit initialization, a register can be
 declared with a reset signal and value. In the following example,
 `myreg`{.firrtl} is assigned the value `myinit`{.firrtl} when the signal
-`myreset`{.firrtl} is high.
+`myreset`{.firrtl} is high.  The reset signal must be a `Reset`{.firrtl},
+`UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and the type of initialization 
+value must be equivalent to the declared type of the register 
+(see [@sec:type-equivalence] for details).
 
 ``` firrtl
 wire myclock: Clock
@@ -901,11 +905,9 @@ reg myreg: SInt, myclock with: (reset => (myreset, myinit))
 ; ...
 ```
 
-Optionally, a register can be
-declared with an enable signal. In the following example,
-`myreg`{.firrtl} is written the value `myval`{.firrtl} when the signal
-`myen`{.firrtl} is high.  Enable must
-be a value of type UInt<1>.
+Optionally, a register can be declared with an enable signal. In the following
+example, `myreg`{.firrtl} is written the value `myval`{.firrtl} when the signal
+`myen`{.firrtl} is high.  Enable must be a value of type UInt<1>.
 
 ``` firrtl
 wire myclock: Clock
@@ -922,11 +924,6 @@ signal, depending only on reset signal.
 ```
 reg myreg: SInt, myclock with: (reset => (myreset, myinit), enable => myen)
 ```
-
-
-Note that the clock signal for a register must be of type `clock`{.firrtl}, the
-reset signal must be a single bit `UInt`{.firrtl}, and the type of
-initialization value must match the declared type of the register.
 
 ## Invalidates
 

--- a/spec.md
+++ b/spec.md
@@ -883,7 +883,7 @@ of the register's clock port.
 The following example demonstrates instantiating a register with the given name
 `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
 `myclock`{.firrtl}.  The clock signal for a register must be of type 
-`clock`{.firrtl}.
+`Clock`{.firrtl}.
 
 ``` firrtl
 wire myclock: Clock

--- a/spec.md
+++ b/spec.md
@@ -919,7 +919,7 @@ myreg <= myval
 ```
 
 When both reset and enable are present, reset shall be listed first, separated
-by a comman from enable.  Reset of the register is unaffected by the enable 
+by a comma from enable.  Reset of the register is unaffected by the enable 
 signal, depending only on reset signal.
 ```
 reg myreg: SInt, myclock with: (reset => (myreset, myinit), enable => myen)

--- a/spec.md
+++ b/spec.md
@@ -876,7 +876,9 @@ wire mywire: UInt
 
 ## Registers
 
-A register is a named stateful circuit component.
+A register is a named stateful circuit component.  Reads from a register return 
+the value of the element, writes are not visible until after the positive edges 
+of the register's clock port.
 
 The following example demonstrates instantiating a register with the given name
 `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
@@ -890,13 +892,16 @@ reg myreg: SInt, myclock
 ```
 
 Optionally, for the purposes of circuit initialization, a register can be
-declared with a reset signal and value. In the following example,
-`myreg`{.firrtl} is assigned the value `myinit`{.firrtl} when the signal
-`myreset`{.firrtl} is high.  The reset signal must be a `Reset`{.firrtl},
-`UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and the type of initialization 
-value must be equivalent to the declared type of the register 
-(see [@sec:type-equivalence] for details).
-
+declared with a reset signal and value. The register's value is updated with the
+reset value when the reset is asserted.  The reset signal must be a 
+`Reset`{.firrtl}, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and the type of 
+initialization  value must be equivalent to the declared type of the register 
+(see [@sec:type-equivalence] for details). The behavior of the register depends 
+on the type of the reset signal.  `AsyncReset`.{firrtl} will immediately change 
+the value of the register, while other types will not change the value of the 
+register until the next positive edge of the clock signal.  In the following 
+example, `myreg`{.firrtl} is assigned the value `myinit`{.firrtl} when the 
+signal `myreset`{.firrtl} is high.  
 ``` firrtl
 wire myclock: Clock
 wire myreset: UInt<1>
@@ -905,9 +910,12 @@ reg myreg: SInt, myclock with: (reset => (myreset, myinit))
 ; ...
 ```
 
-Optionally, a register can be declared with an enable signal. In the following
-example, `myreg`{.firrtl} is written the value `myval`{.firrtl} when the signal
-`myen`{.firrtl} is high.  Enable must be a value of type UInt<1>.
+Optionally, a register can be declared with an enable signal. Enable gates 
+writes to a register, such that they only take effect if the enable signal is 
+high.  Functionally this is equivalent to a register written by a mux of the old 
+value and the new value, controlled by the enable signal.  In the following 
+example, `myreg`{.firrtl} is written the value `myval`{.firrtl} when the signal 
+`myen`{.firrtl} is high.  Enable must be a value of type `UInt<1>`{.firrtl}.
 
 ``` firrtl
 wire myclock: Clock
@@ -920,7 +928,7 @@ myreg <= myval
 
 When both reset and enable are present, reset shall be listed first, separated
 by a comma from enable.  Reset of the register is unaffected by the enable 
-signal, depending only on reset signal.
+signal, depending only on reset signal. 
 ```
 reg myreg: SInt, myclock with: (reset => (myreset, myinit), enable => myen)
 ```


### PR DESCRIPTION
Representation of enable as a mux feeding a register is insufficient as specific tools care about the form of the output for reasoning about enable.  Specifically, they need to be output as if blocks, not as muxes.  However, if and mux have different x behavior in verilog, making it not safe to generally replace a mux with an if.  Further, there is a desire to distingish between a mux before a register and a register with an enable port, making automatic conversion not possible.  Explicitly encoding the enable signal solves both these problems and allows direct expression of intent.

This allows directly capturing the intent expressed by chisel here: https://github.com/chipsalliance/chisel3/blob/v3.5.3/src/main/scala/chisel3/util/Reg.scala#L7