### PR TITLE
Add a version preamble to fir files.  

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -182,8 +182,9 @@ contributors is below:
 
 # File Preamble
 
-A firrtl file includes a magic string and version identifier indicating the 
-version of this standard the file conforms to.  This will not be present on 
+A firrtl file begins with a magic string and version identifier indicating the 
+version of this standard the file conforms to 
+(see [@sec:versioning-scheme-of-this-document]).  This will not be present on 
 files generated according to versions of this standard prior to the first 
 versioned release of this standard to include this preamble.
 
@@ -2919,8 +2920,11 @@ extmodule = "extmodule" , id , ":" , [ info ] , newline , indent ,
               { "parameter" , "=" , ( string | int ) , newline } ,
             dedent ;
 
+(* Wersion definition *)
+version = "FIRRTL" , "version" , {digit_dec} , "."  , {digit_dec} , "." , {digit_dec}
+
 (* Circuit definition *)
-circuit = "circuit" , id , ":" , [ info ] , newline , indent ,
+circuit = version , newline , "circuit" , id , ":" , [ info ] , newline , indent ,
             { module | extmodule } ,
           dedent ;
 ```

--- a/spec.md
+++ b/spec.md
@@ -189,7 +189,7 @@ files generated according to versions of this standard prior to the first
 versioned release of this standard to include this preamble.
 
 ``` firrtl
-firrtl version 1.1.0
+FIRRTL version 1.1.0
 circuit MyTop...
 ```
 

--- a/spec.md
+++ b/spec.md
@@ -180,6 +180,18 @@ contributors is below:
 - [`@tdb-alcorn`](https://github.com/tdb-alcorn)
 - [`@youngar`](https://github.com/youngar)
 
+# File Preamble
+
+A firrtl file includes a magic string and version identifier indicating the 
+version of this standard the file conforms to.  This will not be present on 
+files generated according to versions of this standard prior to the first 
+versioned release of this standard to include this preamble.
+
+``` firrtl
+firrtl version 1.1.0
+circuit MyTop...
+```
+
 # Circuits and Modules
 
 ## Circuits

--- a/spec.md
+++ b/spec.md
@@ -2920,7 +2920,7 @@ extmodule = "extmodule" , id , ":" , [ info ] , newline , indent ,
               { "parameter" , "=" , ( string | int ) , newline } ,
             dedent ;
 
-(* Wersion definition *)
+(* Version definition *)
 version = "FIRRTL" , "version" , {digit_dec} , "."  , {digit_dec} , "." , {digit_dec}
 
 (* Circuit definition *)


### PR DESCRIPTION
Make the version include a unix-style  magic string for file identification.