### PR TITLE
[major] Remove Fixed Point Types

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -7,6 +7,7 @@ revisionHistory:
     - Specify behavior of zero bit width integers, add zero-width literals
     - Add an explicit section about "Aggregate Types" and move "Vector Type" and
       "Bundle Type" under it.
+    - Remove Fixed Point Types.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0

--- a/spec.md
+++ b/spec.md
@@ -252,7 +252,7 @@ composed of one or more aggregate or ground types.
 
 ## Ground Types
 
-There are five ground types in FIRRTL: an unsigned integer type, a signed
+There are four ground types in FIRRTL: an unsigned integer type, a signed
 integer type, a clock type, and an analog type.
 
 ### Integer Types


### PR DESCRIPTION
Remove Fixed Point and any references to it from the FIRRTL
specification.  This (and intervals) was not a FIRRTL feature that
achieved significant traction nor was it ever load-bearing in the same
way that the rest of the specification has been for many years.

This is not in any way intended to be the end of Fixed Point
representations in FIRRTL (or Chisel)!  There are planned future
improvements to provide Fixed Point libraries either directly in Chisel
or via user-defined FIRRTL types once we sort through what that should
look like.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>