### PR TITLE
Bump version to 1.1.0 in prep for release

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4,7 +4,7 @@ author:
 title: Specification for the FIRRTL Language
 date: \today
 # Custom options added to the customized template
-version: 1.0.0
+version: 1.1.0
 # Options passed to the document class
 classoption:
 - 12pt
@@ -45,6 +45,7 @@ lastDelim: ", and"
 
 # Revision History
 
+* 1.1.0 Add a `FIRRTL version` magic string
 * 1.0.0 Document the versioning scheme of this specification.
 * 0.4.0
   - Add documentation for undocumented features of the Scala-based


### PR DESCRIPTION
This would give us a first version that includes a version number so we can start putting that into .fir files.

I believe this is a MINOR bump, since any file that is 1.0.0 compatible is still 1.1.0 compatible which is a MINOR version bump. I believe it is OK from our definition that a file that is 1.1.0 is not parsable by a compiler that could only handle 1.0.0.