### PR TITLE
Use git-tag to compute spec version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Compute a version to use for the specification based on the latest tag.
+VERSION=$(shell git describe --tags --dirty --match 'v*.*.*' | sed 's/^v//')
+
 IMG_SRCS=$(wildcard include/img_src/*.dot)
 IMG_EPSS=$(IMG_SRCS:include/img_src/%.dot=build/img/%.eps)
 
@@ -16,7 +19,8 @@ PANDOC_FLAGS=\
 	--syntax-definition include/firrtl.xml \
 	--syntax-definition include/ebnf.xml \
 	-r markdown+table_captions+inline_code_attributes+gfm_auto_identifiers \
-	--filter pandoc-crossref
+	--filter pandoc-crossref \
+	--metadata version:$(VERSION)
 
 build/spec.pdf: spec.md include/spec-template.tex include/firrtl.xml include/ebnf.xml $(IMG_EPSS) | build/
 	pandoc $< $(PANDOC_FLAGS) -o $@

--- a/include/spec-template.tex
+++ b/include/spec-template.tex
@@ -521,6 +521,29 @@ $endif$
 $if(has-frontmatter)$
 \mainmatter
 $endif$
+$if(revisionHistory)$
+\section{Revision History}
+\begin{itemize}
+$if(revisionHistory.thisVersion)$
+\item $version$
+$for(revisionHistory.thisVersion)$
+\begin{itemize}
+\item $it$
+\end{itemize}
+$endfor$
+$endif$
+$for(revisionHistory.oldVersions)$
+\item $it.version$
+$if(it.changes)$
+\begin{itemize}
+$for(it.changes)$
+\item $it$
+$endfor$
+\end{itemize}
+$endif$
+$endfor$
+\end{itemize}
+$endif$
 $body$
 
 $if(has-frontmatter)$

--- a/spec.md
+++ b/spec.md
@@ -3,8 +3,6 @@ author:
 - The FIRRTL Specification Contributors
 title: Specification for the FIRRTL Language
 date: \today
-# Custom options added to the customized template
-version: 1.0.0
 # Options passed to the document class
 classoption:
 - 12pt

--- a/spec.md
+++ b/spec.md
@@ -39,23 +39,36 @@ secPrefix:
   - Sections
 # This 'lastDelim' option does not work...
 lastDelim: ", and"
+# Information about revision history.  This is used by the LaTeX template.
+revisionHistory:
+  # Information about what was added in the current version.  This will be
+  # populated using the "version" that the Makefile grabs from git.  Notable
+  # additions to the specification should append entries here.
+  thisVersion:
+    - Add version information to FIRRTL files
+  # Information about the old versions.  This should be static.
+  oldVersions:
+    - version: 1.0.0
+      changes:
+        - Document the versioning scheme of this specification.
+    - version: 0.4.0
+      changes:
+        - >
+          Add documentation for undocumented features of the Scala-based FIRRTL
+          Compiler (SFC) that are de facto a part of the FIRRTL specification
+          due to their widespread use in Chisel and the SFC: Annotations,
+          Targets, Asynchronous Reset,  Abstract Reset
+        - Minor typo corrections and prose clarifications.
+    - version: 0.3.1
+      changes:
+        - Clarify analog usage in registers
+        - Rework authorship as "The FIRRTL Specification Contributors"
+        - Add version information as subtitle
+        - Formatting fixes
+    - version: 0.3.0
+      changes:
+        - Document moved to Markdown
 ---
-
-# Revision History
-
-* 1.0.0 Document the versioning scheme of this specification.
-* 0.4.0
-  - Add documentation for undocumented features of the Scala-based
-    FIRRTL Compiler (SFC) that are de facto a part of the FIRRTL specification
-    due to their widespread use in Chisel and the SFC: Annotations, Targets,
-    Asynchronous Reset,  Abstract Reset
-  - Minor typo corrections and prose clarifications.
-* 0.3.1
-  - Clarify analog usage in registers
-  - Rework authorship as "The FIRRTL Specification Contributors"
-  - Add version information as subtitle
-  - Formatting fixes
-* 0.3.0 Document moved to Markdown
 
 # Introduction
 


### PR DESCRIPTION
Change the way that the version is computed to be derived from the
latest git tag that looks like `v*.*.*`.  This _should_ compose
correctly with the GitHub Action to build/publish the spec once a new
tag is created.  This also has the benefit of never having to manually
update the spec version.  Instead, only a new tag has to be created.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

Closes #33 (as this is an alternative that avoids ever having to bump the version again).

If you build off of a spec version that is some commits after the latest tag you get something like the following:
<img width="513" alt="Screen Shot 2022-08-09 at 21 34 10" src="https://user-images.githubusercontent.com/1018530/183791148-b399afbd-578f-4170-997a-e163723481fe.png">

A clean tag (which is what the CI will do on a release) will give you something like:
<img width="480" alt="Screen Shot 2022-08-09 at 21 35 29" src="https://user-images.githubusercontent.com/1018530/183791275-2c7e790d-4d47-42fc-8f91-6cfe972d9318.png">
For a git history of:

```
* d73da20 (HEAD -> dev/seldridge/use-git-tag-for-version, tag: v1.42.1337, origin/dev/seldridge/use-git-tag-for-version) Use git-tag to compute spec version
* 9aa2f29 (origin/main, origin/HEAD, main) Simplify Makefile image target computation, NFC
* e7199fc Cleanup EBNF Grammar, NFC
* 14660c3 Cleanup Makefile, NFC
* 298b5d7 Change Makefile to work with MacOS make, NFC
| * 4f0a54c (origin/dev/seldridge/rm-fixed-point, dev/seldridge/rm-fixed-point) fixup! Remove Fixed Point Types
| * 699c3bd Remove Fixed Point Types
|/  
* 151302c Whitespace cleanup, NFC
* b1ead76 Add a version preamble to fir files.   (#30)
* a62e593 (tag: v1.0.0) Whitespace changes in spec.md, NFC
```
