### PR TITLE
Expand register text with at least cursory explanation

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -901,7 +901,12 @@ wire mywire: UInt
 
 ## Registers
 
-A register is a named stateful circuit component.
+A register is a named stateful circuit component.  Reads from a register return 
+the value of the element, writes are not visible until after the positive edges 
+of the register's clock port.
+
+The clock signal for a register must be of type `Clock`{.firrtl}.  The type of a 
+register must be a passive type (see [@sec:passive-types]).
 
 The following example demonstrates instantiating a register with the given name
 `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
@@ -914,10 +919,16 @@ reg myreg: SInt, myclock
 ```
 
 Optionally, for the purposes of circuit initialization, a register can be
-declared with a reset signal and value. In the following example,
-`myreg`{.firrtl} is assigned the value `myinit`{.firrtl} when the signal
-`myreset`{.firrtl} is high.
-
+declared with a reset signal and value. The register's value is updated with the
+reset value when the reset is asserted.  The reset signal must be a 
+`Reset`{.firrtl}, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and the type of 
+initialization  value must be equivalent to the declared type of the register 
+(see [@sec:type-equivalence] for details). The behavior of the register depends 
+on the type of the reset signal.  `AsyncReset`.{firrtl} will immediately change 
+the value of the register, while other types will not change the value of the 
+register until the next positive edge of the clock signal (see [@sec:reset-type]).
+In the following example, `myreg`{.firrtl} is assigned the value 
+`myinit`{.firrtl} when the signal `myreset`{.firrtl} is high.  
 ``` firrtl
 wire myclock: Clock
 wire myreset: UInt<1>
@@ -925,11 +936,6 @@ wire myinit: SInt
 reg myreg: SInt, myclock with: (reset => (myreset, myinit))
 ; ...
 ```
-
-Note that the clock signal for a register must be of type `clock`{.firrtl},
-the reset signal must be a `Reset`{.firrtl}, `UInt<1>`{.firrtl}, or
-`AsyncReset`{.firrtl}, and the type of initialization value must be equivalent
-to the declared type of the register (see [@sec:type-equivalence] for details).
 
 ## Invalidates
 

--- a/spec.md
+++ b/spec.md
@@ -918,16 +918,17 @@ reg myreg: SInt, myclock
 ; ...
 ```
 
-A register may be declared with a reset signal and value. The register's value 
+A register may be declared with a reset signal and value.  The register's value 
 is updated with the reset value when the reset is asserted.  The reset signal 
 must be a `Reset`{.firrtl}, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and 
-the type of initialization  value must be equivalent to the declared type of the 
-register (see [@sec:type-equivalence] for details). The behavior of the register 
-depends on the type of the reset signal.  `AsyncReset`.{firrtl} will immediately 
-change the value of the register, while other types will not change the value of 
-the register until the next positive edge of the clock signal (see 
-[@sec:reset-type]).  In the following example, `myreg`{.firrtl} is assigned the 
-value `myinit`{.firrtl} when the signal `myreset`{.firrtl} is high.  
+the type of initialization value must be equivalent to the declared type of the 
+register (see [@sec:type-equivalence] for details).  The behavior of the 
+register depends on the type of the reset signal.  `AsyncReset`.{firrtl} will 
+immediately change the value of the register.  `UInt<1> will not change 
+the value of the register until the next positive edge of the clock signal (see 
+[@sec:reset-type]).  `Reset`.{firrtl} is an abstract reset whose behavior 
+depends on reset inference.  In the following example, `myreg`{.firrtl} is 
+assigned the value `myinit`{.firrtl} when the signal `myreset`{.firrtl} is high.  
 
 ``` firrtl
 wire myclock: Clock

--- a/spec.md
+++ b/spec.md
@@ -902,8 +902,8 @@ wire mywire: UInt
 ## Registers
 
 A register is a named stateful circuit component.  Reads from a register return 
-the value of the element, writes are not visible until after the positive edges 
-of the register's clock port.
+the current value of the element, writes are not visible until after a positive 
+edges of the register's clock port.
 
 The clock signal for a register must be of type `Clock`{.firrtl}.  The type of a 
 register must be a passive type (see [@sec:passive-types]).
@@ -918,17 +918,17 @@ reg myreg: SInt, myclock
 ; ...
 ```
 
-Optionally, for the purposes of circuit initialization, a register can be
-declared with a reset signal and value. The register's value is updated with the
-reset value when the reset is asserted.  The reset signal must be a 
-`Reset`{.firrtl}, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and the type of 
-initialization  value must be equivalent to the declared type of the register 
-(see [@sec:type-equivalence] for details). The behavior of the register depends 
-on the type of the reset signal.  `AsyncReset`.{firrtl} will immediately change 
-the value of the register, while other types will not change the value of the 
-register until the next positive edge of the clock signal (see [@sec:reset-type]).
-In the following example, `myreg`{.firrtl} is assigned the value 
-`myinit`{.firrtl} when the signal `myreset`{.firrtl} is high.  
+A register may be declared with a reset signal and value. The register's value 
+is updated with the reset value when the reset is asserted.  The reset signal 
+must be a `Reset`{.firrtl}, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and 
+the type of initialization  value must be equivalent to the declared type of the 
+register (see [@sec:type-equivalence] for details). The behavior of the register 
+depends on the type of the reset signal.  `AsyncReset`.{firrtl} will immediately 
+change the value of the register, while other types will not change the value of 
+the register until the next positive edge of the clock signal (see 
+[@sec:reset-type]).  In the following example, `myreg`{.firrtl} is assigned the 
+value `myinit`{.firrtl} when the signal `myreset`{.firrtl} is high.  
+
 ``` firrtl
 wire myclock: Clock
 wire myreset: UInt<1>


### PR DESCRIPTION
The text on registers was pretty sparse and didn't hint at their behavior.  Update this and mention the type-dependent reset behavior here.