### PR TITLE
Update revision-history with zero-width changes

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -4,6 +4,7 @@ revisionHistory:
   # populated using the "version" that the Makefile grabs from git.  Notable
   # additions to the specification should append entries here.
   thisVersion:
+    - Specify behavior of zero bit width integers, add zero-width literals
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0


### PR DESCRIPTION
We forgot to record https://github.com/chipsalliance/firrtl-spec/pull/40 in the revision-history.