### PR TITLE
[patch] Specify the behavior of "indeterminate values"

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,6 +5,7 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
     - Specify behavior of zero bit width integers, add zero-width literals
+    - Specify behavior of indeterminate values
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0

--- a/spec.md
+++ b/spec.md
@@ -2767,8 +2767,9 @@ defined with the following constraints.
 * Register initialization is done in a consistent way for all registers.  If 
 code is generated to randomly initialize some registers (or 0 fill them, etc), 
 it should be generated for all registers.
-* All observations of an expression with indeterminate value must see the same 
-value at runtime.  Multiple readers of a value will see the same runtime value.
+* All observations of a unique instance of an expression with indeterminate 
+value must see the same value at runtime.  Multiple readers of a value will see 
+the same runtime value.
 * Indeterminate values are not time-varying.  Time-aware constructs, such as 
 registers, which hold an indeterminate value will return the same runtime value 
 unless something changes the value in a normal way.  For example, an 

--- a/spec.md
+++ b/spec.md
@@ -2781,7 +2781,8 @@ unless something changes the value in a normal way.  For example, an
 uninitialized register will return the same value over multiple clock cycles 
 until it is written (or reset).
 - The value produced at runtime for an expression which produced an intermediate
-value shall only be a function of the inputs of the expression.  For example, an out-of-bounds vector access shall produce the same value for a 
+value shall only be a function of the inputs of the expression.  For example, an
+out-of-bounds vector access shall produce the same value for a 
 given out-of-bounds index and vector contents.
 - Two constructs with indeterminate values place no constraint on the identity 
 of their values.  For example, two uninitialized registers, which therefore 

--- a/spec.md
+++ b/spec.md
@@ -2780,8 +2780,8 @@ registers, which hold an indeterminate value will return the same runtime value
 unless something changes the value in a normal way.  For example, an 
 uninitialized register will return the same value over multiple clock cycles 
 until it is written (or reset).
-- An expression which produces an indeterminate value shall produce the same 
-value for the same input.  For example, an out-of-bounds array access shall 
+- The value produced at runtime for an expression which produced an intermediate
+value shall only be a function of the inputs of the expression.  For example, an out-of-bounds array access shall 
 produce the same value for a given out-of-bounds index and array contents.
 - Two constructs with indeterminate values place no constraint on the identity 
 of their values.  For example, two uninitialized registers, which therefore 

--- a/spec.md
+++ b/spec.md
@@ -984,9 +984,7 @@ module MyModule :
    w.b is invalid
 ```
 
-For the purposes of simulation, invalidated components are initialized to random
-values, and operations involving indeterminate values produce undefined
-behaviour. This is useful for early detection of errors in simulation.
+The handing of invalidated components is covered in [@sec:indeterminate-values].
 
 ### The Invalidate Algorithm
 
@@ -2768,7 +2766,7 @@ value at runtime.  Multiple readers of a value will see the same runtime value.
 registers, which hold an indeterminate value will return the same runtime value 
 unless something changes the value in a normal way.  For example, an 
 uninitialized register will return the same value over multiple clock cycles 
-until it is written.
+until it is written (or reset).
 * Two constructs with indeterminate values place no constraint on the identity 
 of their values.  For example, two uninitialized registers, which therefore 
 contain indeterminate values, do not need to be equal under comparison.

--- a/spec.md
+++ b/spec.md
@@ -899,7 +899,6 @@ The following example demonstrates instantiating a wire with the given name
 wire mywire: UInt
 ```
 
-
 ## Registers
 
 A register is a named stateful circuit component.  Reads from a register return 
@@ -2718,13 +2717,13 @@ the scope of what behavior is observable (i.e., a relaxation of the
 An indeterminate value represents a value which is unknown or unspecified.  
 Indeterminate values are generally implementation defined, with constraints 
 specified below.  An indeterminate value may be assumed to be any specific 
-value, at an implementation's descresion, if, in doing so, all observable 
+value, at an implementation's discresion, if, in doing so, all observable 
 behavior is as if the indeterminate value always took the specific value.
 
 This allows transformations such as the following, where when `a` has an 
 indeterminate value, the implementation chooses to consistently give it a value 
-of 4.  There is no visibility of a when it has an indeterminate value which does 
-not see it as 4.
+of 4.  There is no visibility of `a` when it has an indeterminate value which 
+does not see it as 4.
 ``` firrtl
 module IValue :
   output o : UInt<8>
@@ -2736,7 +2735,7 @@ module IValue :
     a <= UInt<3>("h4")
   o <= a
 ```
-is transfromed to:
+is transformed to:
 ``` firrtl
 module IValue :
   output o : UInt<8>
@@ -2765,7 +2764,7 @@ to randomly initialize some registers (or 0 fill them, etc), it should be
 generated for all registers.
 * All observations of an expression with indeterminate value must see the same 
 value at runtime.  Multiple readers of a value will see the same runtime value.
-* Indeterminate values are not time-varying.  Time-aware construct, such as 
+* Indeterminate values are not time-varying.  Time-aware constructs, such as 
 registers, which hold an indeterminate value will return the same runtime value 
 unless something changes the value in a normal way.  For example, an 
 uninitialized register will return the same value over multiple clock cycles 

--- a/spec.md
+++ b/spec.md
@@ -2718,22 +2718,26 @@ the scope of what behavior is observable (i.e., a relaxation of the
 An indeterminate value represents a value which is unknown or unspecified.  
 Indeterminate values are generally implementation defined, with constraints 
 specified below.  An indeterminate value may be assumed to be any specific 
-value, at an implementation's discretion, if, in doing so, all observable 
-behavior is as if the indeterminate value always took the specific value.
+value (not necessarily literal), at an implementation's discretion, if, in doing
+so, all observable behavior is as if the indeterminate value always took the 
+specific value.
 
 This allows transformations such as the following, where when `a` has an 
 indeterminate value, the implementation chooses to consistently give it a value 
-of 4.  There is no visibility of `a` when it has an indeterminate value which 
-does not see it as 4.
+of 'v'.  An alternate, legal mapping, lets the implementaiton give it the value
+`42`.  In both cases, there is no visibility of `a` when it has an indeterminate
+value which is not mapped to the value the implementaiton choose.
+
 ``` firrtl
 module IValue :
   output o : UInt<8>
   input c : UInt<1>
+  input v : UInt<8>
 
   wire a : UInt<8>
   a is invalid
   when c :
-    a <= UInt<3>("h4")
+    a <= v
   o <= a
 ```
 is transformed to:
@@ -2742,7 +2746,7 @@ module IValue :
   output o : UInt<8>
   input c : UInt<1>
 
-  o <= UInt<3>("h4")
+  o <= v
 ```
 Note that it is equally correct to produce:
 ``` firrtl
@@ -2752,7 +2756,7 @@ module IValue :
 
   wire a : UInt<8>
   when c :
-    a <= UInt<3>("h4")
+    a <= v
    else :
      a <= UInt<3>("h42")
   o <= a
@@ -2770,6 +2774,9 @@ registers, which hold an indeterminate value will return the same runtime value
 unless something changes the value in a normal way.  For example, an 
 uninitialized register will return the same value over multiple clock cycles 
 until it is written (or reset).
+* An expression which produces an indeterminate value shall produce the same 
+value for the same input.  For example, an out-of-bounds array access shall 
+produce the same value for a given out-of-bounds index and array contents.
 * Two constructs with indeterminate values place no constraint on the identity 
 of their values.  For example, two uninitialized registers, which therefore 
 contain indeterminate values, do not need to be equal under comparison.

--- a/spec.md
+++ b/spec.md
@@ -938,7 +938,8 @@ reg myreg: SInt, myclock with: (reset => (myreset, myinit))
 ; ...
 ```
 
-A register is initialized with an indeterminate value (see [@sec:indeterminate-values]).
+A register is initialized with an indeterminate value (see 
+[@sec:indeterminate-values]).
 
 ## Invalidates
 
@@ -1852,7 +1853,9 @@ module MyModule :
 
 The sub-access expression dynamically refers to a sub-element of a vector-typed
 expression using a calculated index. The index must be an expression with an
-unsigned integer type.
+unsigned integer type.  An access to an out-of-bounds element results in an 
+indeterminate value (see [@sec:indeterminate-values]).  Each out-of-bounds 
+element is a different indeterminate value.
 
 The following example connects the n'th sub-element of the `in`{.firrtl} port to
 the `out`{.firrtl} port.

--- a/spec.md
+++ b/spec.md
@@ -2769,21 +2769,21 @@ module IValue :
 
 The behavior of constructs which cause indeterminate values is implementation 
 defined with the following constraints.  
-* Register initialization is done in a consistent way for all registers.  If 
+- Register initialization is done in a consistent way for all registers.  If 
 code is generated to randomly initialize some registers (or 0 fill them, etc), 
 it should be generated for all registers.
-* All observations of a unique instance of an expression with indeterminate 
+- All observations of a unique instance of an expression with indeterminate 
 value must see the same value at runtime.  Multiple readers of a value will see 
 the same runtime value.
-* Indeterminate values are not time-varying.  Time-aware constructs, such as 
+- Indeterminate values are not time-varying.  Time-aware constructs, such as 
 registers, which hold an indeterminate value will return the same runtime value 
 unless something changes the value in a normal way.  For example, an 
 uninitialized register will return the same value over multiple clock cycles 
 until it is written (or reset).
-* An expression which produces an indeterminate value shall produce the same 
+- An expression which produces an indeterminate value shall produce the same 
 value for the same input.  For example, an out-of-bounds array access shall 
 produce the same value for a given out-of-bounds index and array contents.
-* Two constructs with indeterminate values place no constraint on the identity 
+- Two constructs with indeterminate values place no constraint on the identity 
 of their values.  For example, two uninitialized registers, which therefore 
 contain indeterminate values, do not need to be equal under comparison.
 

--- a/spec.md
+++ b/spec.md
@@ -2781,8 +2781,8 @@ unless something changes the value in a normal way.  For example, an
 uninitialized register will return the same value over multiple clock cycles 
 until it is written (or reset).
 - The value produced at runtime for an expression which produced an intermediate
-value shall only be a function of the inputs of the expression.  For example, an out-of-bounds array access shall 
-produce the same value for a given out-of-bounds index and array contents.
+value shall only be a function of the inputs of the expression.  For example, an out-of-bounds vector access shall produce the same value for a 
+given out-of-bounds index and vector contents.
 - Two constructs with indeterminate values place no constraint on the identity 
 of their values.  For example, two uninitialized registers, which therefore 
 contain indeterminate values, do not need to be equal under comparison.

--- a/spec.md
+++ b/spec.md
@@ -2718,7 +2718,7 @@ the scope of what behavior is observable (i.e., a relaxation of the
 An indeterminate value represents a value which is unknown or unspecified.  
 Indeterminate values are generally implementation defined, with constraints 
 specified below.  An indeterminate value may be assumed to be any specific 
-value, at an implementation's discresion, if, in doing so, all observable 
+value, at an implementation's discretion, if, in doing so, all observable 
 behavior is as if the indeterminate value always took the specific value.
 
 This allows transformations such as the following, where when `a` has an 

--- a/spec.md
+++ b/spec.md
@@ -2757,9 +2757,9 @@ module IValue :
 
 The behavior of constructs which cause indeterminate values is implementation 
 defined with the following constraints.  
-* Registers initialization is of a uniform code pattern.  If code is generated 
-to randomly initialize some registers (or 0 fill them, etc), it should be 
-generated for all registers.
+* Register initialization is done in a consistent way for all registers.  If 
+code is generated to randomly initialize some registers (or 0 fill them, etc), 
+it should be generated for all registers.
 * All observations of an expression with indeterminate value must see the same 
 value at runtime.  Multiple readers of a value will see the same runtime value.
 * Indeterminate values are not time-varying.  Time-aware constructs, such as 


### PR DESCRIPTION
Indeterminate values are underspecified.  This expands the constructs with explict indeterminate value to include register initialization.  This further describes the implementation constraints on how indeterminate values behave.  This is intended to make the current behavior, which changes visible behavior of circuits with indeterminate values, consistent with the spec. 
 Namely, current implementations will replace a register with a constant if the constant is written at some point (say reset), if there are no other writes.  This changes the observable state of the register between power-on and first write.