### PR TITLE
[major] Intrinsics and Functions

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -901,7 +901,12 @@ wire mywire: UInt
 
 ## Registers
 
-A register is a named stateful circuit component.
+A register is a named stateful circuit component.  Reads from a register return 
+the current value of the element, writes are not visible until after a positive 
+edges of the register's clock port.
+
+The clock signal for a register must be of type `Clock`{.firrtl}.  The type of a 
+register must be a passive type (see [@sec:passive-types]).
 
 The following example demonstrates instantiating a register with the given name
 `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
@@ -913,10 +918,17 @@ reg myreg: SInt, myclock
 ; ...
 ```
 
-Optionally, for the purposes of circuit initialization, a register can be
-declared with a reset signal and value. In the following example,
-`myreg`{.firrtl} is assigned the value `myinit`{.firrtl} when the signal
-`myreset`{.firrtl} is high.
+A register may be declared with a reset signal and value.  The register's value 
+is updated with the reset value when the reset is asserted.  The reset signal 
+must be a `Reset`{.firrtl}, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and 
+the type of initialization value must be equivalent to the declared type of the 
+register (see [@sec:type-equivalence] for details).  The behavior of the 
+register depends on the type of the reset signal.  `AsyncReset`.{firrtl} will 
+immediately change the value of the register.  `UInt<1> will not change 
+the value of the register until the next positive edge of the clock signal (see 
+[@sec:reset-type]).  `Reset`.{firrtl} is an abstract reset whose behavior 
+depends on reset inference.  In the following example, `myreg`{.firrtl} is 
+assigned the value `myinit`{.firrtl} when the signal `myreset`{.firrtl} is high.  
 
 ``` firrtl
 wire myclock: Clock
@@ -925,11 +937,6 @@ wire myinit: SInt
 reg myreg: SInt, myclock with: (reset => (myreset, myinit))
 ; ...
 ```
-
-Note that the clock signal for a register must be of type `clock`{.firrtl},
-the reset signal must be a `Reset`{.firrtl}, `UInt<1>`{.firrtl}, or
-`AsyncReset`{.firrtl}, and the type of initialization value must be equivalent
-to the declared type of the register (see [@sec:type-equivalence] for details).
 
 ## Invalidates
 

--- a/spec.md
+++ b/spec.md
@@ -175,7 +175,7 @@ FIRRTL version 1.1.0
 circuit MyTop...
 ```
 
-# Circuits and Modules and Functions
+# Circuits, Modules, and Functions
 
 ## Circuits
 

--- a/spec.md
+++ b/spec.md
@@ -252,7 +252,7 @@ by its direction, which may be input or output, a name, and the data type of the
 argument.
 
 Functions participate in width-inference (see [@sec:width-inference]) at 
-invocation sites in the same way modules to at instantiation sites.
+invocation sites in the same way modules do at instantiation sites.
 
 Functions cannot contain memories, registers, or instances.  This makes them
 "stateless"

--- a/spec.md
+++ b/spec.md
@@ -257,7 +257,7 @@ invocation sites in the same way modules do at instantiation sites.
 Functions cannot contain memories, registers, or instances.  This makes them
 "stateless".
 
-Functions can optional specify that they are "pure" functions.  These do not
+Functions can optionally specify that they are "pure" functions.  These do not
 have side-effecting operations (such as printf).
 
 

--- a/spec.md
+++ b/spec.md
@@ -255,7 +255,7 @@ Functions participate in width-inference (see [@sec:width-inference]) at
 invocation sites in the same way modules do at instantiation sites.
 
 Functions cannot contain memories, registers, or instances.  This makes them
-"stateless"
+"stateless".
 
 Functions can optional specify that they are "pure" functions.  These do not
 have side-effecting operations (such as printf).

--- a/spec.md
+++ b/spec.md
@@ -246,43 +246,66 @@ Verilog to downstream tools.
 
 ## Functions
 
-A function has a name, list of arguments, and a list of statements representing
-a data-flow graph of stateless circuit components.  Each argument is specified 
-by its direction, which may be input or output, a name, and the data type of the 
-argument.
+A function has a name, a return type, a list of arguments, and a list of 
+statements representing a data-flow graph of stateless circuit components.  Each
+argument specifies its name and  data type.  Functions have a single return 
+value.  The name of the function serves as the identifier for the return value.
 
 Functions participate in width-inference (see [@sec:width-inference]) at 
 invocation sites in the same way modules do at instantiation sites.
 
-Functions cannot contain memories, registers, or instances.  This makes them
-"stateless".
+Functions cannot contain memories, registers, non-local anotations, or 
+instances.  This makes them "stateless".
 
 Functions can optionally specify that they are "pure" functions.  These do not
 have side-effecting operations (such as printf).
 
 
 ``` firrtl
-function MyPureFunction pure :
+function MyPureFunction UInt pure :
   input foo : UInt
-  output bar : UInt
-  bar <= foo
+  MyPureFunction <= foo
 
-function MyFunction :
+function MyFunction UInt<0> :
   input clk: Clock
   input halt: UInt<1>
   stop(clk, halt, 42) : optional_name
+  MyFunction is invalid
+```
+
+## External Functions
+
+An external function has a name, a return type, and a list of arguments.  Each
+argument specifies its name and  data type.  External functions have a single 
+return value.
+
+The widths of all externally defined function arguments must be specified.  
+Width inference, described in [@sec:width-inference], is not supported for 
+external module arguments or return type.
+
+External functions can optionally specify that they are "pure" functions.  These
+do not have side-effecting operations (such as printf).
+
+``` firrtl
+extfunction MyPureFunction UInt pure :
+  input foo : UInt
+
+extfunction MyFunction UInt<0> :
+  input clk: Clock
+  input halt: UInt<1>
 ```
 
 ## Intrinsics
 
 An intrinsic is a function. Intrinsics have all the components of a function
-except  a list of statements.  An intrinsic is a firrtl implementation provided 
+except a list of statements.  An intrinsic is a firrtl implementation provided 
 function.  The name of intrinsics are implementation defined.  A firrtl 
 implementation shall reject IR with unknown intrinsics.  Being functions,
 intrinsics are stateless.
 
-The widths of all intrinsic ports must be specified.  Width inference, described 
-in [@sec:width-inference], is not supported.
+The widths of all an intrinsic's arguments must be specified.  Width inference, 
+described in [@sec:width-inference], is not supported for intrinsics' arguments 
+or return type.
 
 Intrinsics can be "pure".  These do not have side-effects.  Whether a particular 
 intrinsic is pure or not is implementation defined and implementations shall 
@@ -290,9 +313,8 @@ check that intrinsics declarations have the expected arguments, types, and
 purity.
 
 ``` firrtl
-intrinsic synopsys.4mux.u8 pure :
+intrinsic synopsys.4mux.u8 UInt<8>[4] pure :
   input cond : UInt<2>
-  output bar : Vector<4, UInt<8>>
 ```
 
 
@@ -1596,9 +1618,9 @@ FIRRTL functions and intrinsics are invoked with the `invoke` statement.
 
 ``` firrtl
 circuit Top :
-   function MyFunc : 
+   extfunction MyFunc of UInt : 
      input a : UInt
-     output b : UInt
+
    module MyModule :
       input a: UInt
       output b: UInt


### PR DESCRIPTION
Define functions, invocation, and intrinsics.  Intrinsics provide a way to add simple operations without disturbing the spec (for example, specific verilog cover forms or operations mapping to specific vendor primitives).  These also provide a basis for generalized vector operations in the future.

Still a work in progress.