### PR TITLE
[patch] Add Explicit Info About Aggregate Types

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,6 +5,8 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
     - Specify behavior of zero bit width integers, add zero-width literals
+    - Add an explicit section about "Aggregate Types" and move "Vector Type" and
+      "Bundle Type" under it.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0

--- a/spec.md
+++ b/spec.md
@@ -246,9 +246,9 @@ Verilog to downstream tools.
 
 # Types
 
-Types are used to specify the structure of the data held by each circuit
-component. All types in FIRRTL are either one of the fundamental ground types or
-are built up from aggregating other types.
+FIRRTL has two classes of types: _ground_ types and _aggregate_ types.  Ground
+types are fundamental and are not composed of other types.  Aggregate types are
+composed of one or more aggregate or ground types.
 
 ## Ground Types
 
@@ -460,7 +460,12 @@ Analog<32> ; 32-bit analog type
 Analog     ; analog type with inferred width
 ```
 
-## Vector Types
+## Aggregate Types
+
+FIRRTL supports two aggregate types: vectors and bundles.  Aggregate types are
+composed of ground types or other aggregate types.
+
+### Vector Types
 
 A vector type is used to express an ordered sequence of elements of a given
 type. The length of the sequence must be non-negative and known.
@@ -487,7 +492,7 @@ each of which is a ten element vector of 16-bit unsigned integers.
 UInt<16>[10][20]
 ```
 
-## Bundle Types
+### Bundle Types
 
 A bundle type is used to express a collection of nested and named types.  All
 fields in a bundle type must have a given name, and type.


### PR DESCRIPTION
Add clarifications to the spec that FIRRTL has both ground types and aggregate types.  The latter term "aggregate types" is used, but not defined.  Also, restructure the spec to include an explicit "aggregate types" section that is at the same level as "ground types"  Move vector and bundle types under this new "aggregate types" section.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>