### PR TITLE
[patch] Move head and tail to primop_1expr1int_keyword (minor grammar change)

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -9,6 +9,8 @@ revisionHistory:
     - Add an explicit section about "Aggregate Types" and move "Vector Type" and
       "Bundle Type" under it.
     - Remove Fixed Point Types.
+    - Move "head" and "tail" from primop_1expr_keyword to primop_1expr1int_keyword
+      in the "FIRRTL Language Definition".
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0

--- a/spec.md
+++ b/spec.md
@@ -2819,12 +2819,11 @@ primop_2expr =
 primop_1expr_keyword =
     "asUInt" | "asSInt" | "asClock" | "cvt"
   | "neg"    | "not"
-  | "andr"   | "orr"    | "xorr"
-  | "head"   | "tail" ;
+  | "andr"   | "orr"    | "xorr" ;
 primop_1expr =
     primop_1expr_keyword , "(" , expr , ")" ;
 primop_1expr1int_keyword =
-    "pad" | "shl" | "shr" ;
+    "pad" | "shl" | "shr" | "head" | "tail" ;
 primop_1expr1int =
     primop_1exrp1int_keyword , "(", expr , "," , int , ")" ;
 primop_1expr2int_keyword =

--- a/spec.md
+++ b/spec.md
@@ -2002,7 +2002,7 @@ asClock(x)
 [@sec:primitive-operations] will describe the format and semantics of each
 primitive operation.
 
-# Primitive Operations
+# Primitive Operations {#sec:primitive-operations}
 
 The arguments of all primitive operations must be expressions with ground types,
 while their parameters are static integer literals. Each specific operation can


### PR DESCRIPTION
The `head` and `tail`  operations have one argument and one parameter (see Sections 9.24 and 9.25 of the spec v1.1.0) but are listed in the `primop_1expr_keyword` rule of the grammar. This pull request moves these operations to the `primop_1expr1int_keyword` rule.

I also manually added a label to Section 9 "Primitive Operations" (i.e. `{#sec:primitive-operations}`). This section was referenced by its name in other parts of the document. As Section 8.11 has the same name, it was referenced instead of the intended Section 9. 