### PR TITLE
[Clarification] Allow sub-access to convert to sub-index.

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -21,6 +21,7 @@ revisionHistory:
     - Remove FIRRTL forms and lowering, indicate that high-level constructs may
       be preserved by a FIRRTL compiler
     - Add Compiler Implementation Details documenting Lower Types pass
+    - Allow out-of-bounds errors to be caught at compile time.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0

--- a/spec.md
+++ b/spec.md
@@ -1809,7 +1809,9 @@ The sub-access expression dynamically refers to a sub-element of a vector-typed
 expression using a calculated index. The index must be an expression with an
 unsigned integer type.  An access to an out-of-bounds element results in an 
 indeterminate value (see [@sec:indeterminate-values]).  Each out-of-bounds 
-element is a different indeterminate value.
+element is a different indeterminate value.  Sub-access operations with constant
+index may be convereted to sub-index operations even though it converts
+indeterminate-value-on-out-of-bounds behavior to a compile-time error.
 
 The following example connects the n'th sub-element of the `in`{.firrtl} port to
 the `out`{.firrtl} port.


### PR DESCRIPTION
Strictly speaking, sub-index and sub-access have different out-of-bounds behaviors.  Since a sub-access returnes an indeterminate value and sub-index has a compile-time error, one cannot convert sub-access with constant index to a sub-index if the index is out-of-bounds.  This explicitly allows that conversion.