### PR TITLE
Remove cover message in FIRRTL

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1641,7 +1641,7 @@ wire pred: UInt<1>
 wire en: UInt<1>
 pred <= eq(X, Y)
 en <= Z_valid
-cover(clk, pred, en, "X equals Y when Z is valid") : optional_name
+cover(clk, pred, en) : optional_name
 ```
 
 # Expressions


### PR DESCRIPTION
This PR removes `message` field in cover, according to [reply](https://github.com/chipsalliance/chisel3/pull/2912#issuecomment-1366303618) from @ekiwi:
> How is this message supposed to be displayed by different backends like SymbiYosys or Jasper Gold?
The reason cover does not have a message was that there did not seem to be a way to display it with the existing tools. If you want to give your cover points a name, you should be able to just use cover(...).suggestName("name")

Basically, there is no `message` field in System Verilog Spec defined at 19.5 Defining coverage points, for both MFC and SFC, they are not using `message` here, and Chisel is always generating empty message for cover(see chipsalliance/chisel3#2912).