### PR TITLE
[major] Remove Discussion of FIRRTL Forms

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -18,6 +18,9 @@ revisionHistory:
       Compiler implementations
     - Fix spelling/grammar issues
     - Remove partial connect ("<-")
+    - Remove FIRRTL forms and lowering, indicate that high-level constructs may
+      be preserved by a FIRRTL compiler
+    - Add Compiler Implementation Details documenting Lower Types pass
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0


### PR DESCRIPTION
Remove all discussion of FIRRTL forms and lowering, i.e., high/mid/low FIRRTL.  Add language to indicate that high-level constructs may be preserved or eliminated by a FIRRTL compiler implementation.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>