### PR TITLE
[major] Remove validIf

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -13,6 +13,7 @@ revisionHistory:
       primop_1expr1int_keyword in the "FIRRTL Language Definition".
     - Add in-line annotation format
     - Specify behavior of combinational loops
+    - Remove conditionally valid expression (`validif`)
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0


### PR DESCRIPTION
Remove the validIf expression from the spec.  This expression is an artifact of the Scala-based FIRRTL Compiler's internal representation and how it lowers conditional expressions.  It is not necessary that this is part of the public-facing FIRRTL spec.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>