### PR TITLE
[major] Change connect to be truncating

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -14,6 +14,8 @@ revisionHistory:
     - Add in-line annotation format
     - Specify behavior of combinational loops
     - Remove conditionally valid expression (`validif`)
+    - Change connect to truncate widths to align with all existing FIRRTL
+      Compiler implementations
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0

--- a/spec.md
+++ b/spec.md
@@ -625,20 +625,19 @@ In order for a connection to be legal the following conditions must hold:
 1.  The types of the left-hand and right-hand side expressions must be
     equivalent (see [@sec:type-equivalence] for details).
 
-2.  The bit widths of the two expressions must allow for data to always flow
-    from a smaller bit width to an equal size or larger bit width.
-
-3.  The flow of the left-hand side expression must be sink or duplex (see
+2.  The flow of the left-hand side expression must be sink or duplex (see
     [@sec:flows] for an explanation of flow).
 
-4.  Either the flow of the right-hand side expression is source or duplex, or
+3.  Either the flow of the right-hand side expression is source or duplex, or
     the right-hand side expression has a passive type.
 
 Connect statements from a narrower ground type component to a wider ground type
 component will have its value automatically sign-extended or zero-extended to
-the larger bit width. The behaviour of connect statements between two circuit
-components with aggregate types is defined by the connection algorithm in
-[@sec:the-connection-algorithm].
+the larger bit width. Connect statements from a wider ground type component to a
+narrower ground type component will have its value automatically truncated to
+fit the smaller bit width. The behaviour of connect statements between two
+circuit components with aggregate types is defined by the connection algorithm
+in [@sec:the-connection-algorithm].
 
 ### The Connection Algorithm
 


### PR DESCRIPTION
Change the FIRRTL spec to state that connects are truncating (like partial connects).  This has always been the way that connects work in the Scala-based FIRRTL Compiler and the spec was always incorrect here.

My plan here is to remove partial connect and eventually add a "strict connect" operator that does neither truncation nor sign extension.  (This has been used for a while internal to the MLIR-based FIRRTL Compiler to great benefit.)

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>