### PR TITLE
[major] Remove Partial Connect (<-)

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -17,6 +17,7 @@ revisionHistory:
     - Change connect to truncate widths to align with all existing FIRRTL
       Compiler implementations
     - Fix spelling/grammar issues
+    - Remove partial connect ("<-")
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0


### PR DESCRIPTION
Remove the partial connect operation ("<-").  This commit should be merged once it is no longer possible for Chisel to emit partial connects.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>