### PR TITLE
[patch] Fix minor spelling and grammar issues

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -16,6 +16,7 @@ revisionHistory:
     - Remove conditionally valid expression (`validif`)
     - Change connect to truncate widths to align with all existing FIRRTL
       Compiler implementations
+    - Fix spelling/grammar issues
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0

--- a/spec.md
+++ b/spec.md
@@ -276,7 +276,7 @@ SInt
 
 #### Zero Bit Width Integers
 
-Integers of width zero are permissable. They are always zero extended.
+Integers of width zero are permissible. They are always zero extended.
 Thus, when used in an operation that extends to a positive bit width, they
 behave like a zero. While zero bit width integer carry no information, we
 allow 0-bit integer constant zeros for convenience:
@@ -635,7 +635,7 @@ Connect statements from a narrower ground type component to a wider ground type
 component will have its value automatically sign-extended or zero-extended to
 the larger bit width. Connect statements from a wider ground type component to a
 narrower ground type component will have its value automatically truncated to
-fit the smaller bit width. The behaviour of connect statements between two
+fit the smaller bit width. The behavior of connect statements between two
 circuit components with aggregate types is defined by the connection algorithm
 in [@sec:the-connection-algorithm].
 
@@ -1238,7 +1238,7 @@ w <= a
 
 See [@sec:indeterminate-values] for more information on indeterminate values.
 
-The behaviour of conditional connections to circuit components with aggregate
+The behavior of conditional connections to circuit components with aggregate
 types can be modeled by first expanding each connect into individual connect
 statements on its ground elements (see [@sec:the-connection-algorithm;
 @sec:the-partial-connection-algorithm] for the connection and partial connection
@@ -1315,7 +1315,7 @@ by the following parameters.
     cycles after setting the port's write address and data before the
     corresponding element within the memory holds the new value.
 
-6.  A read-under-write flag indicating the behaviour when a memory location is
+6.  A read-under-write flag indicating the behavior when a memory location is
     written to while a read to that location is in progress.
 
 The following example demonstrates instantiating a memory containing 256 complex
@@ -1414,7 +1414,7 @@ should be used accordingly. If the readwrite port is in write mode (the
 `addr`{.firrtl}, `en`{.firrtl}, and `clk`{.firrtl} fields constitute its write
 port fields, and should be used accordingly.
 
-### Read Under Write Behaviour
+### Read Under Write Behavior
 
 The read-under-write flag indicates the value held on a read port's
 `data`{.firrtl} field if its memory location is written to while it is reading.
@@ -1455,7 +1455,7 @@ the same for overlapping clock periods, or when any portion of a read operation
 overlaps part of a write operation with a matching addresses. In such cases, the
 data that is read out of the read port is undefined.
 
-### Write Under Write Behaviour
+### Write Under Write Behavior
 
 In all cases, if a memory location is written to by more than one port on the
 same cycle, the stored value is undefined.
@@ -2653,9 +2653,9 @@ specific value.
 
 This allows transformations such as the following, where when `a` has an
 indeterminate value, the implementation chooses to consistently give it a value
-of 'v'.  An alternate, legal mapping, lets the implementaiton give it the value
+of 'v'.  An alternate, legal mapping, lets the implementation give it the value
 `42`.  In both cases, there is no visibility of `a` when it has an indeterminate
-value which is not mapped to the value the implementaiton choose.
+value which is not mapped to the value the implementation chooses.
 
 ``` firrtl
 module IValue :
@@ -2686,8 +2686,8 @@ module IValue :
   wire a : UInt<8>
   when c :
     a <= v
-   else :
-     a <= UInt<3>("h42")
+  else :
+    a <= UInt<3>("h42")
   o <= a
 ```
 


### PR DESCRIPTION
It looked like we were using "behavior" (10 instances) more than "behaviour" (5 instances), so I went with the more common one.