### PR TITLE
Minor grammar changes

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1309,7 +1309,7 @@ analog types within the component (as they cannot be connected to).
 
 ### Alternate Syntax
 
-`is invalid`.{.firrtl} may also be specified by keyword.
+`is invalid`{.firrtl} may also be specified by keyword.
 
 ``` firrtl
 module MyModule :

--- a/spec.md
+++ b/spec.md
@@ -3672,11 +3672,11 @@ statement = "wire" , id , ":" , type , [ info ]
           | reference , "<=" , expr , [ info ]
           | reference , "is invalid" , [ info ]
           | "attach(" , reference , { "," ,  reference } , ")" , [ info ]
-          | "when" , expr , ":" [ info ] , newline , indent ,
-              statement, { statement } ,
-            dedent , [ "else" , ":" , indent , statement, { statement } , dedent ]
-          | "stop(" , expr , "," , expr , "," , int_any , ")" , [ info ]
-          | "printf(" , expr , "," , expr , "," , string_dq ,
+          | "when" , expr , ":" [ info ] , newline ,
+            indent , statement, { statement } , dedent ,
+            [ "else" , ":" , indent , statement, { statement } , dedent ]
+          | "stop(" , expr , "," , expr , "," , int , ")" , [ info ]
+          | "printf(" , expr , "," , expr , "," , string ,
             { expr } , ")" , [ ":" , id ] , [ info ]
           | "skip" , [ info ]
           | "define" , static_reference , "=" , ref_expr , [ info ]

--- a/spec.md
+++ b/spec.md
@@ -3588,7 +3588,7 @@ letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
 id = ( "_" | letter ) , { "_" | letter | digit_dec } ;
 
 (* Fileinfo communicates Chisel source file and line/column info *)
-linecol = num_dec , ":" , num_dec ;
+linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;
 lineinfo = string, " ", linecol
 info = "@" , "[" , lineinfo, { ",", lineinfo }, "]" ;
 
@@ -3677,7 +3677,7 @@ statement = "wire" , id , ":" , type , [ info ]
             indent , statement, { statement } , dedent ,
             [ "else" , ":" , indent , statement, { statement } , dedent ]
           | "stop(" , expr , "," , expr , "," , int , ")" , [ info ]
-          | "printf(" , expr , "," , expr , "," , string ,
+          | "printf(" , expr , "," , expr , "," , string_dq ,
             { expr } , ")" , [ ":" , id ] , [ info ]
           | "skip" , [ info ]
           | "define" , static_reference , "=" , ref_expr , [ info ]
@@ -3709,7 +3709,7 @@ intmodule = "intmodule" , id , ":" , [ info ] , newline , indent ,
 annotations = "%" , "[" , json_array , "]" ;
 
 (* Version definition *)
-sem_ver = num_dec , "."  , num_dec , "." , num_dec
+sem_ver = int , "."  , int , "." , int
 version = "FIRRTL" , "version" , sem_ver ;
 
 (* Circuit definition *)

--- a/spec.md
+++ b/spec.md
@@ -1072,7 +1072,7 @@ field.
 
 ### Alternate Syntax
 
-Connects may also be specified by keyword.  This form is identical to the `<=` 
+Connects may also be specified by keyword.  This form is identical to the `<=`
 form in operand order
 
 ``` firrtl
@@ -3641,7 +3641,7 @@ ref_expr = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
            | static_reference ;
 
 (* Memory *)
-ruw = ( "old" | "new" | "undefined" ) ;
+ruw =  "old" | "new" | "undefined" ;
 memory = "mem" , id , ":" , [ info ] , newline , indent ,
            "data-type" , "=>" , type , newline ,
            "depth" , "=>" , int , newline ,
@@ -3721,7 +3721,7 @@ circuit =
 
 ## Deprecated Syntax
 
-`reference is invalid` and `reference <= expr` are deprecated and will be 
+`reference is invalid` and `reference <= expr` are deprecated and will be
 replaced with the alternate syntax in the next major revision.
 
 # Versioning Scheme of this Document

--- a/spec.md
+++ b/spec.md
@@ -3589,7 +3589,8 @@ id = ( "_" | letter ) , { "_" | letter | digit_dec } ;
 
 (* Fileinfo communicates Chisel source file and line/column info *)
 linecol = num_dec , ":" , num_dec ;
-info = "@" , "[" , { string , " " , linecol } , "]" ;
+lineinfo = string, " ", linecol
+info = "@" , "[" , lineinfo, { ",", lineinfo }, "]" ;
 
 (* Type definitions *)
 width = "<" , int_any , ">" ;

--- a/spec.md
+++ b/spec.md
@@ -3708,7 +3708,7 @@ intmodule = "intmodule" , id , ":" , [ info ] , newline , indent ,
 annotations = "%" , "[" , json_array , "]" ;
 
 (* Version definition *)
-sem_ver = { digit_dec } , "."  , { digit_dec } , "." , { digit_dec }
+sem_ver = { digit_dec }+ , "."  , { digit_dec }+ , "." , { digit_dec }+
 version = "FIRRTL" , "version" , sem_ver ;
 
 (* Circuit definition *)

--- a/spec.md
+++ b/spec.md
@@ -3588,7 +3588,7 @@ letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
 id = ( "_" | letter ) , { "_" | letter | digit_dec } ;
 
 (* Fileinfo communicates Chisel source file and line/column info *)
-linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;
+linecol = num_dec , ":" , num_dec ;
 info = "@" , "[" , { string , " " , linecol } , "]" ;
 
 (* Type definitions *)
@@ -3708,7 +3708,7 @@ intmodule = "intmodule" , id , ":" , [ info ] , newline , indent ,
 annotations = "%" , "[" , json_array , "]" ;
 
 (* Version definition *)
-sem_ver = { digit_dec }+ , "."  , { digit_dec }+ , "." , { digit_dec }+
+sem_ver = num_dec , "."  , num_dec , "." , num_dec
 version = "FIRRTL" , "version" , sem_ver ;
 
 (* Circuit definition *)

--- a/spec.md
+++ b/spec.md
@@ -3671,7 +3671,7 @@ statement = "wire" , id , ":" , type , [ info ]
           | "node" , id , "=" , expr , [ info ]
           | reference , "<=" , expr , [ info ]
           | reference , "is invalid" , [ info ]
-          | "attach(" , { reference } , ")" , [ info ]
+          | "attach(" , reference , { "," ,  reference } , ")" , [ info ]
           | "when" , expr , ":" [ info ] , newline , indent ,
               statement, { statement } ,
             dedent , [ "else" , ":" , indent , statement, { statement } , dedent ]

--- a/spec.md
+++ b/spec.md
@@ -3197,8 +3197,8 @@ Targets are specific enough to refer to any specific module in a folded,
 unfolded, or partially folded representation.
 
 To show some examples of what these look like, consider the following example
-circuit. This consists of four instances of module `Baz`{.firrtl}, two
-instances of module `Bar`{.firrtl}, and one instance of module `Foo`{.firrtl}:
+circuit. This consists of four instances of module `Baz`{.firrtl}, two instances
+of module `Bar`{.firrtl}, and one instance of module `Foo`{.firrtl}:
 
 ```firrtl
 circuit Foo:

--- a/spec.md
+++ b/spec.md
@@ -3673,8 +3673,8 @@ statement = "wire" , id , ":" , type , [ info ]
           | reference , "is invalid" , [ info ]
           | "attach(" , { reference } , ")" , [ info ]
           | "when" , expr , ":" [ info ] , newline , indent ,
-              { statement } ,
-            dedent , [ "else" , ":" , indent , { statement } , dedent ]
+              statement, { statement } ,
+            dedent , [ "else" , ":" , indent , statement, { statement } , dedent ]
           | "stop(" , expr , "," , expr , "," , int_any , ")" , [ info ]
           | "printf(" , expr , "," , expr , "," , string_dq ,
             { expr } , ")" , [ ":" , id ] , [ info ]

--- a/spec.md
+++ b/spec.md
@@ -3685,7 +3685,7 @@ statement = "wire" , id , ":" , type , [ info ]
           | "invalidate" , reference , [ info ]
 
 (* Module definitions *)
-port = ( "input" | "output" ) , id , ":": , type , [ info ] ;
+port = ( "input" | "output" ) , id , ":" , type , [ info ] ;
 module = "module" , id , ":" , [ info ] , newline , indent ,
            { port , newline } ,
            { statement , newline } ,


### PR DESCRIPTION
I am currently writing a FIRRTL lexer for [Pygments](https://pygments.org/) and stumbled upon some minor issues in the formal specification that I fixed. Furthermore I found some curiosities in the specs as well as a mismatch between what Chisel 3.5.5. produces and what is described in the spec. 

### Fixes
* Removal of unnecessary parentheses and a spurious colon
* Allowing to create decimal integer expressions (the compilers, of course, always allowed for that)
* Enforcing an `at least once` constraint in many places. The grammar uses `{ rule }` quite often when `rule , { rule }` should have been used. I do not know what formalism exactly is used in the "FIRRTL Language Definition", but as it looks XBNF enough for me, I opted to use the `{ rule }+` notation to indicate the "at least once" constraint.

### Curiosities
#### Names 
The rule `id = ("_" | letter) , {"_" | letter | digit_dec)` allows for a name to be a single underscore only. The compiler   happily accepts this:
```Scala
val emptyNameExample =
    """
circuit emptyName :
  module emptyName :
    output _ : UInt<4>		
    out <= UInt(0)
"""
```

   ```
[info] running mhbs.FIRRTLParse 
FIRRTL version 1.1.0
circuit emptyName :
  module emptyName :
    output _ : UInt<4>

    out <= UInt<1>("h0")
```

   Is this intended behavior?

#### Comments
The rule `info = "@" , "[" , { string , " " , linecol } , "]" ;` allows for empty comments. The compiler happily accepts this:
```Scala
val emptyCommentExample =
    """
circuit emptyComment :
  module emptyComment :
    output out : SInt<4> @[]		
    out <= SInt(0)
"""
```

```
[info] running mhbs.FIRRTLParse 
FIRRTL version 1.1.0
circuit emptyComment :
  module emptyComment :
    output out : SInt<4>

    out <= SInt<1>("h0")
```

Is this intended behavior?

### Mismatches for registers

When using Chisel 3.5.5 registers result in the following 
```Scala
class RegisterExample extends Module{
    val out = IO(Output(UInt(4.W)))
    val r = RegInit(0.U(4.W))
    out := r
}
```
```
    reg r : UInt<4>, clock with :
      reset => (reset, UInt<4>("h0")) @[RegisterExample.scala 8:20]
```

while the spec would lead to
```
reg r: UInt<4> clock (with: {reset => (UInt<4>("h0"), r)})
```

Is the spec just newer than the Chisel version?