### PR TITLE
[Major] Explicit compile time constant expressions.

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -22,6 +22,7 @@ revisionHistory:
       be preserved by a FIRRTL compiler
     - Add Compiler Implementation Details documenting Lower Types pass
     - Allow out-of-bounds errors to be caught at compile time.
+    - Define constant type modifier.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0

--- a/spec.md
+++ b/spec.md
@@ -503,17 +503,18 @@ flows into the module, and the `d`{.firrtl} sub-field contained in the
 
 ### Constant Type
 
-A constant type is a type whose value is guaranteed to be a compile-time 
-constant.  Constant types may be used in ports, wire, nodes, and generally 
-anywhere a non-constant type is usable.  Operations on constant type are well 
-defined.  As a general rule (with any exception listed in the definition for 
-such operations as have exceptions), an operation whose arguments are constant
-produces a constant.  An operations with some non-constant arguments produce a
-non-constant.  Constants can be used in any context with a source flow which 
-allows a non-constant.  Constants may be used as the target of a connect so long 
-as the source of the connect is itself constant.  These rules ensure all 
-constants are derived from literals or from constant-typed input ports of the 
-top-level module.
+A constant type is a type whose value is guaranteed to be unchanging at circuit 
+execution time.  Constant is a constraint on the mutability of the value, it 
+does not imply a literal value at a point in the emitted design.  Constant types 
+may be used in ports, wire, nodes, and generally anywhere a non-constant type is 
+usable.  Operations on constant type are well defined.  As a general rule (with 
+any exception listed in the definition for such operations as have exceptions), 
+an operation whose arguments are constant produces a constant.  An operations 
+with some non-constant arguments produce a non-constant.  Constants can be used 
+in any context with a source flow which allows a non-constant.  Constants may be 
+used as the target of a connect so long as the source of the connect is itself 
+constant.  These rules ensure all constants are derived from literals or from 
+constant-typed input ports of the top-level module.
 
 ``` firrtl
 const UInt<3>
@@ -528,8 +529,8 @@ means if a constant is being assigned to in a `when` block, the `when`'s
 condition must be a constant.
 
 Output ports of external modules and input ports to the top-level module may be
-constant.  In such case, the value of the port is not known, but that it is time
-invariant at runtime is known.
+constant.  In such case, the value of the port is not known, but that it is 
+non-mutating at runtime is known.
 
 The indexing of a constant aggregate produces a constant of the appropriate type 
 for the element.
@@ -771,7 +772,8 @@ the current value of the element, writes are not visible until after a positive
 edges of the register's clock port.
 
 The clock signal for a register must be of type `Clock`{.firrtl}.  The type of a
-register must be a passive type (see [@sec:passive-types]) and may not be const.
+register must be a passive type (see [@sec:passive-types]) and may not be 
+`const`.{.firrtl}.
 
 The following example demonstrates instantiating a register with the given name
 `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
@@ -1692,7 +1694,8 @@ will be rewritten as "the port `in`{.firrtl} is connected to the port
 
 The sub-field expression refers to a sub-element of an expression with a bundle
 type.  If the expression is of a constant bundle type, the sub-element shall be 
-of a constant type.
+of a constant type (`const`.{firrtl} propagates from the bundle to the element 
+on indexing).
 
 The following example connects the `in`{.firrtl} port to the `a`{.firrtl}
 sub-element of the `out`{.firrtl} port.
@@ -1703,6 +1706,26 @@ module MyModule :
   output out: {a: UInt, b: UInt}
   out.a <= in
 ```
+
+The following example is the same as above, but with a constant output bundle.
+
+``` firrtl
+module MyModule :
+  input in: const UInt
+  output out: const {a: UInt, b: UInt}
+  out.a <= in // out.a is of type const UInt
+```
+
+The following example is the same as above, but with a bundle with a constant 
+field.
+
+``` firrtl
+module MyModule :
+  input in: const UInt
+  output out: {a: const UInt, b: UInt}
+  out.a <= in // out.a is of type const UInt
+```
+
 
 ## Sub-indices
 
@@ -1721,6 +1744,16 @@ module MyModule :
   output out: UInt[10]
   out[4] <= in
 ```
+
+The following example is the same as above, but with a constant vector.
+
+``` firrtl
+module MyModule :
+  input in: const UInt
+  output out: const UInt[10]
+  out[4] <= in // out[4] has a type of const UInt
+```
+
 
 ## Sub-accesses
 

--- a/spec.md
+++ b/spec.md
@@ -1371,6 +1371,12 @@ data that is read out of the read port is undefined.
 In all cases, if a memory location is written to by more than one port on the
 same cycle, the stored value is undefined.
 
+### Constant memory type
+
+A memory with a constant data-type represents a ROM and may not have 
+write-ports.  It is beyond the scope of this specification how ROMs are 
+initialized.
+
 ## Instances
 
 FIRRTL modules are instantiated with the instance statement. The following

--- a/spec.md
+++ b/spec.md
@@ -2711,7 +2711,8 @@ type_ground = "Clock" | "Reset" | "AsyncReset"
 type_aggregate = "{" , field , { field } , "}"
                | type , "[" , int , "]" ;
 field = [ "flip" ] , id , ":" , type ;
-type = type_ground | type_aggregate ;
+consttype = "const", type_ground | type_aggregate
+type = type_ground | type_aggregate | consttype ;
 
 (* Primitive operations *)
 primop_2expr_keyword =

--- a/spec.md
+++ b/spec.md
@@ -540,13 +540,13 @@ for the element.
 Constant types are a restriction on FIRRTL types.  Therefore, FIRRTL structures 
 which would be expected to produce certain Verilog structures will produce the
 same structure if instantiated with a constant type.  For example, an input port
-of type `const UInt` will result in a port in the verilog, if under the same
+of type `const UInt` will result in a port in the Verilog, if under the same
 conditions an input port of type `UInt` would have.
 
 It is not intended that constants are a replacement for parameterization.  
 Constant typed values have no particular meta-programming capability.  It is,
 for example, expected that a module with a constant input port be fully 
-compilable to non-parameterized verilog.
+compilable to non-parameterized Verilog.
 
 
 ## Passive Types

--- a/spec.md
+++ b/spec.md
@@ -499,6 +499,54 @@ the module.  The `c`{.firrtl} sub-field contained in the `b`{.firrtl} sub-field
 flows into the module, and the `d`{.firrtl} sub-field contained in the
 `b`{.firrtl} sub-field flows out of the module.
 
+## Type Modifiers
+
+### Constant Type
+
+A constant type is a type whose value is guaranteed to be a compile-time 
+constant.  Constant types may be used in ports, wire, nodes, and generally 
+anywhere a non-constant type is usable.  Operations on constant type are well 
+defined.  As a general rule (with any exception listed in the definition for 
+such operations as have exceptions), an operation whose arguments are constant
+produces a constant.  Operations, except where noted, do not take a mixture of 
+constant and non-constant arguments.  Constants can be used in any context with 
+a source flow which allows a non-constant.  Constants may be used as the target 
+of a connect so long as the source of the connect is itself constant.  These 
+rules ensure all constants are derived from literals or from input ports to the 
+top-level module which are constant.
+
+``` firrtl
+const UInt<3>
+const SInt
+const {real: UInt<32>, imag : UInt<32>}
+const 
+
+Last-connect semantics of constant typed values is well defined, so long as any 
+control flow is conditioned on an expression which has a constant type.  This 
+means if a constant is being assigned to in a `when` block, the `when`'s 
+condition must be a constant.
+
+Output ports of external modules and input ports to the top-level module may be
+constant.  In such case, the value of the port is not known, but that it is time
+invariant at runtime is known.
+
+The indexing of a constant aggregate produces a constant of the appropriate type 
+for the element.
+
+#### A note on implementation
+
+Constant types are a restriction on firrtl types.  Therefore, firrtl structures 
+which would be expected to produce certain verilog structures will produce the
+same structure if instantiated with a constant type.  For example, an input port
+of type `const UInt` will result in a port in the verilog, if under the same
+conditions an input port of type `UInt` would have.
+
+It is not intended that constants are a replacement for parameterization.  
+Constant typed values have no particular meta-programming capability.  It is,
+for example, expected that a module with a constant input port be fully 
+compilable to non-parameterized verilog.
+
+
 ## Passive Types
 
 It is inappropriate for some circuit components to be declared with a type that

--- a/spec.md
+++ b/spec.md
@@ -508,12 +508,12 @@ constant.  Constant types may be used in ports, wire, nodes, and generally
 anywhere a non-constant type is usable.  Operations on constant type are well 
 defined.  As a general rule (with any exception listed in the definition for 
 such operations as have exceptions), an operation whose arguments are constant
-produces a constant.  Operations, except where noted, do not take a mixture of 
-constant and non-constant arguments.  Constants can be used in any context with 
-a source flow which allows a non-constant.  Constants may be used as the target 
-of a connect so long as the source of the connect is itself constant.  These 
-rules ensure all constants are derived from literals or from input ports to the 
-top-level module which are constant.
+produces a constant.  An operations with some non-constant arguments produce a
+non-constant.  Constants can be used in any context with a source flow which 
+allows a non-constant.  Constants may be used as the target of a connect so long 
+as the source of the connect is itself constant.  These rules ensure all 
+constants are derived from literals or from constant-typed input ports of the 
+top-level module.
 
 ``` firrtl
 const UInt<3>
@@ -770,7 +770,7 @@ the current value of the element, writes are not visible until after a positive
 edges of the register's clock port.
 
 The clock signal for a register must be of type `Clock`{.firrtl}.  The type of a
-register must be a passive type (see [@sec:passive-types]).
+register must be a passive type (see [@sec:passive-types]) and may not be const.
 
 The following example demonstrates instantiating a register with the given name
 `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
@@ -1562,8 +1562,8 @@ for performing primitive operations.
 ## Unsigned Integers
 
 A literal unsigned integer can be created given a non-negative integer value and
-an optional positive bit width. The following example creates a 10-bit unsigned
-integer representing the number 42.
+an optional positive bit width. Integer literals are of constant type.  The 
+following example creates a 10-bit unsigned integer representing the number 42.
 
 ``` firrtl
 UInt<10>(42)
@@ -1580,7 +1580,8 @@ UInt(42)
 ## Unsigned Integers from Literal Bits
 
 A literal unsigned integer can alternatively be created given a string
-representing its bit representation and an optional bit width.
+representing its bit representation and an optional bit width.  Like with the
+integer representation, the expression has a constant type.
 
 The following radices are supported:
 
@@ -1617,8 +1618,9 @@ UInt<7>("hD")
 ## Signed Integers
 
 Similar to unsigned integers, a literal signed integer can be created given an
-integer value and an optional positive bit width. The following example creates
-a 10-bit unsigned integer representing the number -42.
+integer value and an optional positive bit width. Integer literals are of 
+constant type.  The following example creates a 10-bit unsigned integer 
+representing the number -42.
 
 ``` firrtl
 SInt<10>(-42)
@@ -1637,7 +1639,8 @@ SInt(-42)
 
 Similar to unsigned integers, a literal signed integer can alternatively be
 created given a string representing its bit representation and an optional bit
-width.
+width.  Like with the integer representation, the expression has a constant 
+type.
 
 The bit representation contains a binary, octal or hex indicator, followed by an
 optional sign, followed by the value.
@@ -1683,7 +1686,8 @@ will be rewritten as "the port `in`{.firrtl} is connected to the port
 ## Sub-fields
 
 The sub-field expression refers to a sub-element of an expression with a bundle
-type.
+type.  If the expression is of a constant bundle type, the sub-element shall be 
+of a constant type.
 
 The following example connects the `in`{.firrtl} port to the `a`{.firrtl}
 sub-element of the `out`{.firrtl} port.
@@ -1699,7 +1703,9 @@ module MyModule :
 
 The sub-index expression statically refers, by index, to a sub-element of an
 expression with a vector type. The index must be a non-negative integer and
-cannot be equal to or exceed the length of the vector it indexes.
+cannot be equal to or exceed the length of the vector it indexes.  If the 
+expression is of a constant vector type, the sub-element shall be of a constant
+type.
 
 The following example connects the `in`{.firrtl} port to the fifth sub-element
 of the `out`{.firrtl} port.
@@ -1715,11 +1721,12 @@ module MyModule :
 
 The sub-access expression dynamically refers to a sub-element of a vector-typed
 expression using a calculated index. The index must be an expression with an
-unsigned integer type.  An access to an out-of-bounds element results in an 
-indeterminate value (see [@sec:indeterminate-values]).  Each out-of-bounds 
-element is a different indeterminate value.  Sub-access operations with constant
-index may be convereted to sub-index operations even though it converts
-indeterminate-value-on-out-of-bounds behavior to a compile-time error.
+unsigned integer type.  If the expression is of a constant vector type, the 
+sub-element shall be of a constant type.  An access to an out-of-bounds element 
+results in an indeterminate value (see [@sec:indeterminate-values]).  Each 
+out-of-bounds element is a different indeterminate value.  Sub-access operations 
+with constant index may be convereted to sub-index operations even though it 
+converts indeterminate-value-on-out-of-bounds behavior to a compile-time error.
 
 The following example connects the n'th sub-element of the `in`{.firrtl} port to
 the `out`{.firrtl} port.
@@ -1890,7 +1897,9 @@ primitive operation.
 The arguments of all primitive operations must be expressions with ground types,
 while their parameters are static integer literals. Each specific operation can
 place additional restrictions on the number and types of their arguments and
-parameters.
+parameters.  Primitive operations may have all their arguments of constant type,
+in which case their return type is of constant type.  If the operation has a 
+mixed constant and non-constant arguments, the result is non-constant.
 
 Notationally, the width of an argument e is represented as w~e~.
 

--- a/spec.md
+++ b/spec.md
@@ -1718,7 +1718,7 @@ The following example is the same as above, but with a constant output bundle.
 module MyModule :
   input in: const UInt
   output out: const {a: UInt, b: UInt}
-  out.a <= in // out.a is of type const UInt
+  out.a <= in ; out.a is of type const UInt
 ```
 
 The following example is the same as above, but with a bundle with a constant 

--- a/spec.md
+++ b/spec.md
@@ -538,7 +538,7 @@ for the element.
 #### A note on implementation
 
 Constant types are a restriction on FIRRTL types.  Therefore, FIRRTL structures 
-which would be expected to produce certain verilog structures will produce the
+which would be expected to produce certain Verilog structures will produce the
 same structure if instantiated with a constant type.  For example, an input port
 of type `const UInt` will result in a port in the verilog, if under the same
 conditions an input port of type `UInt` would have.

--- a/spec.md
+++ b/spec.md
@@ -1756,7 +1756,7 @@ The following example is the same as above, but with a constant vector.
 module MyModule :
   input in: const UInt
   output out: const UInt[10]
-  out[4] <= in // out[4] has a type of const UInt
+  out[4] <= in ; out[4] has a type of const UInt
 ```
 
 

--- a/spec.md
+++ b/spec.md
@@ -537,7 +537,7 @@ for the element.
 
 #### A note on implementation
 
-Constant types are a restriction on firrtl types.  Therefore, firrtl structures 
+Constant types are a restriction on FIRRTL types.  Therefore, FIRRTL structures 
 which would be expected to produce certain verilog structures will produce the
 same structure if instantiated with a constant type.  For example, an input port
 of type `const UInt` will result in a port in the verilog, if under the same

--- a/spec.md
+++ b/spec.md
@@ -518,8 +518,9 @@ top-level module.
 ``` firrtl
 const UInt<3>
 const SInt
-const {real: UInt<32>, imag : UInt<32>}
+const {real: UInt<32>, imag : UInt<32>, other : const SInt}
 const 
+```
 
 Last-connect semantics of constant typed values is well defined, so long as any 
 control flow is conditioned on an expression which has a constant type.  This 

--- a/spec.md
+++ b/spec.md
@@ -1767,7 +1767,7 @@ unsigned integer type.  If the expression is of a constant vector type, the
 sub-element shall be of a constant type.  An access to an out-of-bounds element 
 results in an indeterminate value (see [@sec:indeterminate-values]).  Each 
 out-of-bounds element is a different indeterminate value.  Sub-access operations 
-with constant index may be convereted to sub-index operations even though it 
+with constant index may be converted to sub-index operations even though it 
 converts indeterminate-value-on-out-of-bounds behavior to a compile-time error.
 
 The following example connects the n'th sub-element of the `in`{.firrtl} port to

--- a/spec.md
+++ b/spec.md
@@ -790,7 +790,7 @@ the type of reset value must be equivalent to the declared type of the register
 `AsyncReset`{.firrtl}, then the reset value must be a constant type.  The 
 behavior of the register depends on the type of the reset signal.  
 `AsyncReset`.{firrtl} will immediately change the value of the register.  
-`UInt<1> will not change the value of the register until the next positive edge 
+`UInt<1>`{.firrtl} will not change the value of the register until the next positive edge 
 of the clock signal (see [@sec:reset-type]).  `Reset`.{firrtl} is an abstract 
 reset whose behavior depends on reset inference.  In the following example, 
 `myreg`{.firrtl} is assigned the value `myinit`{.firrtl} when the signal 

--- a/spec.md
+++ b/spec.md
@@ -1728,7 +1728,7 @@ field.
 module MyModule :
   input in: const UInt
   output out: {a: const UInt, b: UInt}
-  out.a <= in // out.a is of type const UInt
+  out.a <= in ; out.a is of type const UInt
 ```
 
 

--- a/spec.md
+++ b/spec.md
@@ -785,14 +785,16 @@ reg myreg: SInt, myclock
 A register may be declared with a reset signal and value.  The register's value
 is updated with the reset value when the reset is asserted.  The reset signal
 must be a `Reset`{.firrtl}, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and
-the type of initialization value must be equivalent to the declared type of the
-register (see [@sec:type-equivalence] for details).  The behavior of the
-register depends on the type of the reset signal.  `AsyncReset`.{firrtl} will
-immediately change the value of the register.  `UInt<1> will not change
-the value of the register until the next positive edge of the clock signal (see
-[@sec:reset-type]).  `Reset`.{firrtl} is an abstract reset whose behavior
-depends on reset inference.  In the following example, `myreg`{.firrtl} is
-assigned the value `myinit`{.firrtl} when the signal `myreset`{.firrtl} is high.
+the type of reset value must be equivalent to the declared type of the register 
+(see [@sec:type-equivalence] for details).  If the reset signal is an 
+`AsyncReset`{.firrtl}, then the reset value must be a constant type.  The 
+behavior of the register depends on the type of the reset signal.  
+`AsyncReset`.{firrtl} will immediately change the value of the register.  
+`UInt<1> will not change the value of the register until the next positive edge 
+of the clock signal (see [@sec:reset-type]).  `Reset`.{firrtl} is an abstract 
+reset whose behavior depends on reset inference.  In the following example, 
+`myreg`{.firrtl} is assigned the value `myinit`{.firrtl} when the signal 
+`myreset`{.firrtl} is high.
 
 ``` firrtl
 wire myclock: Clock

--- a/spec.md
+++ b/spec.md
@@ -509,7 +509,7 @@ does not imply a literal value at a point in the emitted design.  Constant types
 may be used in ports, wire, nodes, and generally anywhere a non-constant type is 
 usable.  Operations on constant type are well defined.  As a general rule (with 
 any exception listed in the definition for such operations as have exceptions), 
-an operation whose arguments are constant produces a constant.  An operations 
+an operation whose arguments are constant produces a constant.  An operation 
 with some non-constant arguments produce a non-constant.  Constants can be used 
 in any context with a source flow which allows a non-constant.  Constants may be 
 used as the target of a connect so long as the source of the connect is itself 

--- a/spec.md
+++ b/spec.md
@@ -520,10 +520,9 @@ constant-typed input ports of the top-level module.
 const UInt<3>
 const SInt
 const {real: UInt<32>, imag : UInt<32>, other : const SInt}
-const 
 ```
 
-Last-connect semantics of constant typed values is well defined, so long as any 
+Last-connect semantics of constant typed values are well defined, so long as any 
 control flow is conditioned on an expression which has a constant type.  This 
 means if a constant is being assigned to in a `when` block, the `when`'s 
 condition must be a constant.
@@ -2747,8 +2746,7 @@ type_ground = "Clock" | "Reset" | "AsyncReset"
 type_aggregate = "{" , field , { field } , "}"
                | type , "[" , int , "]" ;
 field = [ "flip" ] , id , ":" , type ;
-consttype = "const", type_ground | type_aggregate
-type = type_ground | type_aggregate | consttype ;
+type = [ "const" ], ( type_ground | type_aggregate ) ;
 
 (* Primitive operations *)
 primop_2expr_keyword =


### PR DESCRIPTION
Add a constant type modifier for compile-time evaluation (under whole-world assumptions).  Constant types in external ports implies that uses of constant types are not guaranteed to be know at compile time (this is not a mechanism to guarantee constant propagation).

Asynchronous resets are updated to take constant reset values.  This moves ad-hoc checks which exist in implementations now to type checks.  This is not sufficient for some tools, but is a strict improvement on the current implementations.

The change of asyncreset value is what makes this a major change.