### PR TITLE
[nfc] Fix markdown list, separate with blank line before.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2430,6 +2430,7 @@ module IValue :
 
 The behavior of constructs which cause indeterminate values is implementation
 defined with the following constraints.
+
 - Register initialization is done in a consistent way for all registers.  If
 code is generated to randomly initialize some registers (or 0 fill them, etc),
 it should be generated for all registers.


### PR DESCRIPTION
At least on my local pandoc/etc setup, without the newline it renders like:

![image](https://user-images.githubusercontent.com/104031989/217302196-582a572e-1b9a-4515-b5bc-68eeef982448.png)

After:

![image](https://user-images.githubusercontent.com/104031989/217302325-e9f5070c-5c7f-4798-b2f7-b6d31d199ce0.png)
