### PR TITLE
[patch] Drop language about width of conditionally valid.

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -24,6 +24,7 @@ revisionHistory:
     - Allow out-of-bounds errors to be caught at compile time.
     - Clarify the string argument for cover is a comment, not a message
       as it is for assert and assume.
+    - Remove stray language leftover from removing conditionally valid.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.1.0

--- a/spec.md
+++ b/spec.md
@@ -2162,9 +2162,6 @@ corresponding input widths. For multiplexing aggregate-typed expressions, the
 resulting widths of each leaf sub-element is the maximum of its corresponding
 two input leaf sub-element widths.
 
-The width of a conditionally valid expression is the width of its input
-expression.
-
 The width of each primitive operation is detailed in [@sec:primitive-operations].
 
 The width of the integer literal expressions is detailed in their respective


### PR DESCRIPTION
Condtionally valid (`validif`) was removed in 9890f17f2d .