### PR TITLE
[patch] Fix missing ports in indeterminate example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2431,6 +2431,7 @@ is transformed to:
 module IValue :
   output o : UInt<8>
   input c : UInt<1>
+  input v : UInt<8>
 
   o <= v
 ```
@@ -2439,6 +2440,7 @@ Note that it is equally correct to produce:
 module IValue :
   output o : UInt<8>
   input c : UInt<1>
+  input v : UInt<8>
 
   wire a : UInt<8>
   when c :


### PR DESCRIPTION
My assumption is that the examples provided are missing the `input v` port that was defined in the earlier example. Otherwise, `v` is undefined in the circuit.