### PR TITLE
[major] Add reference types.

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -18,6 +18,8 @@
       <item>of</item>
       <item>wire</item>
       <item>node</item>
+      <item>ref</item>
+      <item>define</item>
     </list>
     <list name="types">
       <item>UInt</item>
@@ -27,6 +29,10 @@
       <item>Clock</item>
       <item>Reset</item>
       <item>AsyncReset</item>
+    </list>
+    <list name="outertype">
+      <item>Probe</item>
+      <item>RWProbe</item>
     </list>
     <list name="typemodifiers">
       <item>const</item>
@@ -81,11 +87,19 @@
       <item>assert</item>
       <item>assume</item>
       <item>cover</item>
+      <item>read</item>
+      <item>probe</item>
+      <item>rwprobe</item>
+      <item>force</item>
+      <item>release</item>
+      <item>force_initial</item>
+      <item>release_initial</item>
     </list>
     <contexts>
       <context name="Normal Text" attribute="ID" lineEndContext="#pop">
         <keyword attribute="Keyword" context="#stay" String="keywords" />
         <keyword attribute="Keyword" context="type" String="types" />
+        <keyword attribute="Keyword" context="outertype" String="outertype" />
         <keyword attribute="Keyword" context="#stay" String="typemodifiers" />
         <keyword attribute="Structure" context="#stay" String="structure" />
         <keyword attribute="PrimOp" context="#stay" String="primops" />
@@ -108,6 +122,7 @@
       <context name="memory" attribute="Keyword" lineEndContext="#stay">
         <Detect2Chars char="=" char1="&gt;" attribute="Operator" context="memoryRHS"/>
         <StringDetect String="read-under-write" attribute="Keyword" context="#pop!memoryLast"/>
+        <DetectChar char= ";" context="comment" attribute="Comment"/>
       </context>
       <context name="memoryRHS" attribute="ID" lineEndContext="#pop">
         <keyword String="types" attribute="Keyword" context="type"/>
@@ -133,11 +148,21 @@
       <context name="info" attribute="Info" lineEndContext="#stay">
         <DetectChar char="]" context="#pop"/>
       </context>
+      <context name="outertype" attribute="Keyword" lineEndContext="#pop">
+        <DetectChar char="&lt;" attribute="Operator" context="#stay"/>
+        <keyword String="types" attribute="Keyword" context="type"/>
+        <DetectChar char="{" context="field" attribute="Separator"/>
+        <DetectChar char="}" attribute="Separator" context="#pop#pop"/>
+        <DetectChar char= ";" context="comment" attribute="Comment"/>
+        <AnyChar String="&gt;," attribute="Operator" context="#pop"/>
+        <DetectChar char="[" attribute="Operator" context="widthOrDepthOrLit"/>
+      </context>
       <context name="type" attribute="String" lineEndContext="#pop">
         <AnyChar String="&lt;[(" attribute="Operator" context="widthOrDepthOrLit"/>
         <AnyChar String="," attribute="Separator" context="#pop"/>
         <AnyChar String="}" attribute="Separator" context="#pop#pop"/>
         <DetectChar char= ";" context="comment" attribute="Comment"/>
+        <AnyChar String="&gt;" attribute="Operator" context="#pop"/>
       </context>
       <context name="widthOrDepthOrLit" attribute="String" lineEndContext="#stay">
         <DetectChar char="&lt;" attribute="Operator" context="widthOrDepthOrLit"/>
@@ -146,6 +171,7 @@
       <context name="field" attribute="ID" lineEndContext="#stay">
         <StringDetect String="flip" attribute="Keyword" context="#stay"/>
         <keyword String="types" attribute="Keyword" context="type"/>
+        <keyword String="outertype" attribute="Keyword" context="outertype"/>
         <keyword String="typemodifiers" attribute="Keyword" context="#stay"/>
         <DetectChar char="{" attribute="Separator" context="field"/>
         <DetectChar char="}" attribute="Separator" context="#pop"/>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -15,6 +15,7 @@ revisionHistory:
     - Render inline annotations as JSON, fix typo in example.
     - Fix rendering of type modifiers (const) in document.
     - Fix grammar for registers.
+    - Add reference types and related statements.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.2.0

--- a/spec.md
+++ b/spec.md
@@ -633,7 +633,7 @@ module NoSubAccessesWithProbes :
 ```
 
 Probe types may be specified as part of an external module (see
-[@sec:externally-defined-modules]), with the resolved referent optionally
+[@sec:externally-defined-modules]), with the resolved referent for each
 specified using `ref`{.firrtl} statements.
 
 Probe types may target `const`{.firrtl} signals, but cannot use

--- a/spec.md
+++ b/spec.md
@@ -221,9 +221,8 @@ order, an optional _defname_ which sets the name of the external module in the
 resulting Verilog, zero or more name--value _parameter_ statements, and zero or
 more _ref_ statements indicating the resolved paths of the module's exported
 references.  Each name--value parameter statement will result in a value being
-passed to the named parameter in the resulting Verilog.  While `ref` statements
-are optional, they are required to be present if the reference is used.
-
+passed to the named parameter in the resulting Verilog.  Every port or port
+sub-element of reference type must have exactly one `ref`{.firrtl} statement.
 
 An example of an externally defined module is:
 

--- a/spec.md
+++ b/spec.md
@@ -1948,8 +1948,9 @@ Nested declarations (see [@sec:nested-declarations]) may be exported:
 
 ```firrtl
 module RefProducer :
-  input a : UInt
+  input a : UInt<4>
   input en : UInt<1>
+  input clk : Clock
   output thereg : Probe<UInt>
 
   when en :

--- a/spec.md
+++ b/spec.md
@@ -1886,8 +1886,7 @@ module Refs:
   output a : Probe<{x: UInt, y: UInt}> ; read-only ref. to wire 'p'
   output b : RWProbe<UInt> ; force-able ref. to node 'q', inferred width.
   output c : Probe<UInt<1>> ; read-only ref. to register 'r'
-  output d : RWProbe<UInt<2>>[4] ; vector of ref.'s to memory data in 'm'
-  output e : Probe<Clock> ; ref. to input clock port
+  output d : Probe<Clock> ; ref. to input clock port
 
   wire p : {x: UInt, flip y : UInt}
   define a = probe(p) ; probe is passive
@@ -1895,14 +1894,7 @@ module Refs:
   define b = rwprobe(q)
   reg r: UInt, clock
   define c = probe(r)
-  mem m:
-    data-type => UInt<5>
-    depth => 4
-    ; ...
-    read-under-write => undefined
-
-  define d = rwprobe(m)
-  define e = probe(clock)
+  define d = probe(clock)
 ```
 
 The target is not required to be only an identifier, it may be a field within a
@@ -2616,9 +2608,8 @@ The probe expression creates a reference to a read-only or force-able view of
 the data underlying the specified reference expression.
 
 The type of the produced probe reference is always passive, but the probed
-expression may not be.
-
-Probed memories produce a vector of references to their data.
+expression may not be.  Memories and their ports are not supported as probe
+targets.
 
 There are two probe varieties: `probe`{.firrtl} and `rwprobe`{.firrtl} for
 producing probes of type `Probe`{.firrtl} and `RWProbe`{.firrtl}, respectively.

--- a/spec.md
+++ b/spec.md
@@ -552,14 +552,14 @@ For use in cross-module references (hierarchical references in Verilog), a
 reference to a probe of the circuit component is used.  See [@sec:probes] for
 details.
 
-Using reference-type ports, modules may expose internals for reading and
-forcing without routing wires out of the design.
+Using probe-type ports, modules may expose internals for reading and forcing
+without routing wires out of the design.
 
-This is often useful for testing and verification, where reference types allow
+This is often useful for testing and verification, where probe types allow
 reads of the entities to be explicitly exported without hard-coding their place
-in the design.  Instead, by using references, a testbench module may express
-accesses to the internals which will resolve to the appropriate target language
-construct by the compiler (e.g., hierarchical reference).
+in the design.  Instead, by using probe-type references, a testbench module may
+express accesses to the internals which will resolve to the appropriate target
+language construct by the compiler (e.g., hierarchical reference).
 
 Reference ports are not expected to be synthesizable or representable in the
 target language and are omitted in the compiled design; they only exist at the

--- a/spec.md
+++ b/spec.md
@@ -641,7 +641,7 @@ Probe types may target `const`{.firrtl} signals, but cannot use
 `RWProbe<const T>`{.firrtl}, as constant values should never be mutated at
 runtime.
 
-### Width and Reset Inference
+#### Width and Reset Inference
 
 Probe types do participate in global width and reset inference, but only in the
 direction of the reference itself (no inference in the other direction, even
@@ -1873,9 +1873,10 @@ location is not significant other than scoping, and do not have last-connect
 semantics.  Every sink-flow probe must be the target of exactly one of these
 statements.
 
-The define statement takes a sink-flow static reference target and sets
-it to the specified reference, which must either be a probe
-expression, or a static reference source.
+The define statement takes a sink-flow static reference target and sets it to
+the specified reference, which must either be a probe expression, or a static
+reference source.
+
 
 Example:
 
@@ -1924,6 +1925,13 @@ module Foo:
 
 `RWProbe`{.firrtl} references to ports are not allowed on public-facing
 modules.
+
+Define statements can set a `Probe`{.firrtl} to either a `Probe`{.firrtl} or
+`RWProbe`{.firrtl}, but a `RWProbe`{.firrtl} cannot be set to a
+`Probe`{.firrtl}.  The inner types of the two references must (recursively) be
+identical or identical with the destination containing uninferred versions of
+the corresponding element in the source type.  See
+[@sec:width-and-reset-inference] for details.
 
 #### Probes and Passive Types
 

--- a/spec.md
+++ b/spec.md
@@ -578,7 +578,7 @@ underlying circuit constructs they originate from, captured using
 possible, as read-only probes impose fewer limitations and are more amenable to
 optimization.
 
-References must always be able to be statically traced to their target, or to
+Probe references must always be able to be statically traced to their target, or to
 an external module's output reference.  This means no conditional connections
 via sub-accesses, multiplexers, or other means.
 
@@ -591,11 +591,12 @@ There are two probe types: `Probe`{.firrtl} and `RWProbe`{.firrtl}.
 
 Probe types are parametric over the type of data that they refer to, which is
 always passive (as defined in [@sec:passive-types]) even when the probed target
-is not (see [@sec:probes-and-passive-types]).  Probe types cannot contain probe
-types.
+is not (see [@sec:probes-and-passive-types]).  Probe types cannot contain
+reference types.
 
 Conceptually probe types are single-direction views of the probed data-flow
-point.
+point.  They are references to the data accessed with the probe expression
+generating the reference.
 
 Examples:
 
@@ -673,7 +674,7 @@ circuit ResetInferGood :
     out2 <= in
 ```
 
-### Input References
+### Input Probe References
 
 Probe references are generally forwarded up the design hierarchy, being used to
 reach down into design internals from a higher point.  As a result probe-type
@@ -687,10 +688,10 @@ reference paths.  When probe references are used to access the underlying data
 statically known element at or below the point of that use, in all contexts.
 Support for other scenarios are allowed as determined by the implementation.
 
-Input references are not allowed on public-facing modules: e.g., the top module
+Input probe references are not allowed on public-facing modules: e.g., the top module
 and external modules.
 
-Examples of input references follow.
+Examples of input probe references follow.
 
 #### U-Turn Example
 
@@ -770,10 +771,10 @@ circuit Top:
 
 #### IO with references to endpoint data
 
-A primary motivation for input references is that in some situations they make
-it easier to generate the FIRRTL code.  While output references necessarily
-capture this design equivalently, this can be harder to generate and so is
-useful to support.
+A primary motivation for input probe references is that in some situations they
+make it easier to generate the FIRRTL code.  While output references
+necessarily capture this design equivalently, this can be harder to generate
+and so is useful to support.
 
 The following demonstrates an example of this, where it's convenient to use the
 same bundle type as both output to one module and input to another, with
@@ -781,7 +782,7 @@ references populated by both modules targeting signals of interest at each end.
 For this to be the same bundle type -- input on one and output on another --
 the `Probe` references for each end should be output-oriented and accordingly
 are input-oriented at the other end.  It would be inconvenient to generate this
-design so that each has output references only.
+design so that each has output probe references only.
 
 The `Connect` module instantiates a `Producer` and `Consumer` module, connects
 them using a bundle with references in both orientations, and forwards those
@@ -1910,8 +1911,8 @@ semantics.  Every sink-flow probe must be the target of exactly one of these
 statements.
 
 The define statement takes a sink-flow static reference target and sets it to
-the specified reference, which must either be a probe expression, or a static
-reference source.
+the specified reference, which must either be a compatible probe expression or
+static reference source.
 
 
 Example:
@@ -2034,7 +2035,7 @@ using input reference-type ports, which are allowed but should be used
 carefully as they make it possible to express
 invalid reference paths.
 
-See [@sec:input-references] for more details, a small example is given below:
+See [@sec:input-probe-references] for more details, a small example is given below:
 
 ```firrtl
 module UnusedInputRef :

--- a/spec.md
+++ b/spec.md
@@ -652,7 +652,8 @@ contained reset type is similarly only inferred in the direction of the
 reference, even if it eventually reaches a known reset type.
 
 In the following example, the FIRRTL compiler will produce an error constrasted
-with inferring the input port as `AsyncReset`{.firrtl} if a direct connection was used:
+with inferring the input port as `AsyncReset`{.firrtl} if a direct connection
+was used:
 
 ```firrtl
 circuit ResetInferBad :
@@ -662,7 +663,8 @@ circuit ResetInferBad :
     out <= read(probe(in))
 ```
 
-The following circuit has all resets inferred to `AsyncReset`{.firrtl}, however:
+The following circuit has all resets inferred to `AsyncReset`{.firrtl},
+however:
 
 ```firrtl
 circuit ResetInferGood :

--- a/spec.md
+++ b/spec.md
@@ -2041,9 +2041,9 @@ module AddRefs:
   output c : RWProbe<UInt<2>>
   output sum : UInt<3>
 
-  node x = Uint<2>(0)
-  node y : UInt<2>(0)
-  node z : UInt<2>(0)
+  node x = UInt<2>(0)
+  node y = UInt<2>(0)
+  node z = UInt<2>(0)
   sum <= add(x, add(y, z))
 
   define a = rwprobe(x)

--- a/spec.md
+++ b/spec.md
@@ -218,9 +218,12 @@ Externally defined modules are modules whose implementation is not provided in
 the current circuit.  Only the ports and name of the externally defined module
 are specified in the circuit.  An externally defined module may include, in
 order, an optional _defname_ which sets the name of the external module in the
-resulting Verilog and zero or more name--value _parameter_ statements.  Each
-name--value parameter statement will result in a value being passed to the named
-parameter in the resulting Verilog.
+resulting Verilog, zero or more name--value _parameter_ statements, and zero or
+more _ref_ statements indicating the resolved paths of the module's exported
+references.  Each name--value parameter statement will result in a value being
+passed to the named parameter in the resulting Verilog.  While `ref` statements
+are optional, they are required to be present if the reference is used.
+
 
 An example of an externally defined module is:
 
@@ -241,6 +244,22 @@ ports.
 A common use of an externally defined module is to represent a Verilog module
 that will be written separately and provided together with FIRRTL-generated
 Verilog to downstream tools.
+
+An example of an externally defined module with references is:
+
+```firrtl
+extmodule MyExternalModuleWithRefs :
+  input foo : UInt<2>
+  output mysignal : Probe<UInt<1>>
+  output myreg : RWProbe<UInt<8>>
+  ref mysignal is "a.b"
+  ref myreg is "x.y"
+```
+These resolved reference paths capture important information for use in the
+current FIRRTL design. While they are part of the FIRRTL-level interface to the
+external module, they are not expected to correspond to a particular Verilog
+construct. They exist to carry information about the implementation of the
+extmodule necessary for code generation of the current circuit.
 
 ## Implementation Defined Modules (Intrinsics)
 
@@ -267,9 +286,11 @@ intmodule MyIntrinsicModule_xhello_y64 :
 
 # Types
 
-FIRRTL has two classes of types: _ground_ types and _aggregate_ types.  Ground
-types are fundamental and are not composed of other types.  Aggregate types are
-composed of one or more aggregate or ground types.
+FIRRTL has three classes of types: _ground_ types, _aggregate_ types, and
+_reference_ types.  Ground types are fundamental and are not composed of other
+types.  Aggregate types and reference types are composed of one or more
+aggregate or ground types.  Reference types may not contain other reference
+types.
 
 ## Ground Types
 
@@ -521,6 +542,214 @@ In a connection to `myport`{.firrtl}, the `a`{.firrtl} sub-field flows out of
 the module.  The `c`{.firrtl} sub-field contained in the `b`{.firrtl} sub-field
 flows into the module, and the `d`{.firrtl} sub-field contained in the
 `b`{.firrtl} sub-field flows out of the module.
+
+
+## Reference Types
+
+References can be exported from a module for indirect access elsewhere, and are
+captured using values of reference type.
+
+For use in cross-module references (hierarchical references in Verilog), a
+reference to a probe of the circuit component is used.  See [@sec:probes] for
+details.
+
+Using reference-type ports, modules may expose internals for reading and
+forcing without routing wires out of the design.
+
+This is often useful for testing and verification, where reference types allow
+reads of the entities to be explicitly exported without hard-coding their place
+in the design.  Instead, by using references, a testbench module may express
+accesses to the internals which will resolve to the appropriate target language
+construct by the compiler (e.g., hierarchical reference).
+
+Reference ports are not expected to be synthesizable or representable in the
+target language and are omitted in the compiled design; they only exist at the
+FIRRTL level.
+
+Reference-type ports are statically routed through the design using the
+`define`{.firrtl} statement.
+
+There are two reference types, `Probe`{.firrtl} and `RWProbe`{.firrtl},
+described below.  These are used for indirect access to probes of the data
+underlying circuit constructs they originate from, captured using
+`probe`{.firrtl} expressions (see [@sec:probes]).
+
+`Probe`{.firrtl} types are read-only, and `RWProbe`{.firrtl} may be used with
+`force`{.firrtl} and related statements.  Prefer the former as much as
+possible, as read-only probes impose fewer limitations and are more amenable to
+optimization.
+
+References must always be able to be statically traced to their target, or to
+an external module's output reference.  This means no conditional connections
+via sub-accesses, multiplexers, or other means.
+
+### Probe Types
+
+Probe types are reference types used to access circuit elements' data remotely.
+
+There are two probe types: `Probe`{.firrtl} and `RWProbe`{.firrtl}.
+`RWProbe`{.firrtl} is a `Probe`{.firrtl} type, but not the other way around.
+
+Probe types are parametric over the type of data that they refer to, which is
+always passive (as defined in [@sec:passive-types]) even when the probed target
+is not (see [@sec:probes-and-passive-types]).  Probe types cannot contain probe
+types.
+
+Conceptually probe types are single-direction views of the probed data-flow
+point.
+
+Examples:
+
+```firrtl
+Probe<UInt> ; readable reference to unsigned integer with inferred width
+RWProbe<{x: {y: UInt}}> ; readable and forceable reference to bundle
+```
+
+For details of how to read and write through probe types, see
+[@sec:reading-probe-references;@sec:force-and-release].
+
+All ports of probe type must be initialized with exactly one `define`{.firrtl}
+statement.
+
+Probe types are only allowed as part of module ports and may not appear
+anywhere else.
+
+Sub-accesses are not allowed with types where the result is or has probe types
+within.  This is because sub-accesses are essentially conditional connections
+(see [@sec:sub-accesses] for details), which are not allowed with probe types.
+The following example demonstrates some legal and illegal expressions:
+```firrtl
+module NoSubAccessesWithProbes :
+  input x : {a : Probe<UInt[2]>, b : UInt}[3]
+  input i : UInt
+  input c : const UInt
+  output p : Probe<UInt>
+
+  ; Illegal: x[i], x[c]
+  ; Illegal: x[0].a[i], x[0].a[c]
+
+  ; Legal:
+  define p = x[0].a[1]
+```
+
+Probe types may be specified as part of an external module (see
+[@sec:externally-defined-modules]), with the resolved referent optionally
+specified using `ref`{.firrtl} statements.
+
+### Input References
+
+Probe references are generally forwarded up the design hierarchy, being used to
+reach down into design internals from a higher point.  As a result probe-type
+references are most often output ports, but may also be used on input ports
+internally, as described in this section.
+
+Input probe references are allowed on internal modules, but they should be used
+with care because they make it possible to express invalid reference paths.
+When probe references are used to access the underlying data (e.g., with a
+`read`{.firrtl} or `force`{.firrtl}), they must target a statically known
+element at or below the point of that use.  Support for other scenarios are
+allowed as determined by the implementation.
+
+Input references are not allowed on public-facing modules: e.g., the top module
+and external modules.
+
+Examples of input references follow.
+
+#### U-Turn Example
+
+```firrtl
+module UTurn:
+  input in : Probe<UInt>
+  output out : Probe<UInt>
+  define out = in
+
+module RefBouncing:
+  input x: UInt
+  output y: UInt
+
+  inst u1 of UTurn
+  inst u2 of UTurn
+
+  node n = x
+  define u1.in = probe(n)
+  define u2.in = u1.out
+
+  out <= read(u2.out) ; = x
+```
+
+In the above example, the probe of node `n`{.firrtl} is routed through two
+modules before its resolution.
+
+#### Invalid Input Reference
+
+When using a probe reference, the target must reside at or below the point of use
+in the design hierarchy.  Input references make it possible to create designs
+where this is not the case, and such upwards references are not supported:
+
+```firrtl
+module Foo:
+   input in : Probe<UInt>
+   output out : UInt
+
+   out <= read(in)
+```
+
+#### IO with references to endpoint data
+
+A primary motivation for input references is that in some situations they make
+it easier to generate the FIRRTL code.  While output references necessarily
+capture this design equivalently, this can be harder to generate and so is
+useful to support.
+
+The following demonstrates an example of this, where it's convenient to use the
+same bundle type as both output to one module and input to another, with
+references populated by both modules targeting signals of interest at each end.
+For this to be the same bundle type -- input on one and output on another --
+the `Probe` references for each end should be output-oriented and accordingly
+are input-oriented at the other end.  It would be inconvenient to generate this
+design so that each has output references only.
+
+The `Connect` module instantiates a `Producer` and `Consumer` module, connects
+them using a bundle with references in both orientations, and forwards those
+references for inspection up the hierarchy.  The probe targets are not
+significant, here they are the same data being sent between the two, as stored
+in each module.
+
+```firrtl
+module Consumer:
+  input in : {a: UInt, pref: Probe<UInt>, flip cref: Probe<UInt>}
+  ; ...
+  node n = in.a
+  define in.cref = probe(n)
+
+module Producer:
+  output out : {a: UInt, pref: Probe<UInt>, flip cref: Probe<UInt>}
+  wire x : UInt
+  define out.pref = probe(x)
+  ; ...
+  out.a <= x
+
+module Connect:
+  output out : {x: Probe<UInt>, y: Probe<UInt>}
+
+  inst a of A
+  inst b of B
+
+  ; A => B
+  a.in.a <= b.out.a
+  define a.in.pref = b.out.pref
+  define b.out.cref = a.in.cref
+
+  ; Send references out
+  define out.pref = b.out.pref
+  define out.cref = a.in.cref
+
+module Top:
+  inst c of Connect
+
+  node producer_debug = read(c.pref); ; Producer-side signal
+  node consumer_debug = read(c.cref); ; Consumer-side signal
+```
 
 ## Type Modifiers
 
@@ -889,6 +1118,9 @@ sub-element in the vector.
 
 Invalidating a component with a bundle type recursively invalidates each
 sub-element in the bundle.
+
+Components of reference and analog type are ignored, as are any reference or
+analog types within the component (as they cannot be connected to).
 
 ## Attaches
 
@@ -1586,12 +1818,330 @@ en <= Z_valid
 cover(clk, pred, en, "X equals Y when Z is valid") : optional_name
 ```
 
+## Probes
+
+Probe references are created with `probe`{.firrtl} expressions, routed through
+the design using the `define`{.firrtl} statement, read using the
+`read`{.firrtl} expression (see [@sec:reading-probe-references]), and forced
+and released with `force`{.firrtl} and `release`{.firrtl} statements.
+
+These statements are detailed below.
+
+### Define
+
+Define statements are used to route references through the design, and may be
+used wherever is most convenient in terms of available identifiers -- their
+location is not significant other than scoping, and do not have last-connect
+semantics.  Every sink-flow probe must be the target of exactly one of these
+statements.
+
+The define statement takes a sink-flow static reference target and sets
+it to the specified reference, which must either be a probe
+expression, or a static reference source.
+
+Example:
+
+```firrtl
+module Refs:
+  input clock:  Clock
+  output a : Probe<{x: UInt, y: UInt}> ; read-only ref. to wire 'p'
+  output b : RWProbe<UInt> ; force-able ref. to node 'q', inferred width.
+  output c : Probe<UInt<1>> ; read-only ref. to register 'r'
+  output d : RWProbe<UInt<2>>[4] ; vector of ref.'s to memory data in 'm'
+  output e : Probe<Clock> ; ref. to input clock port
+
+  wire p : {x: UInt, flip y : UInt}
+  define a = probe(p) ; probe is passive
+  node q = UInt<1>(0)
+  define b = rwprobe(q)
+  reg r: UInt, clock
+  define c = probe(r)
+  mem m:
+    data-type => UInt<5>
+    depth => 4
+    ; ...
+    read-under-write => undefined
+
+  define d = rwprobe(m)
+  define e = probe(clock)
+```
+
+The target is not required to be only an identifier, it may be a field within a
+bundle or other statically known sub-element of an aggregate, for example:
+
+```firrtl
+module Foo:
+  input x : UInt
+  output y : {x: UInt, p: Probe<UInt>}
+  output z : Probe<UInt>[2]
+
+  wire w : UInt
+  w <= x
+  y.x <= w
+
+  define y.p = probe(w)
+  define z[0] = probe(w)
+  define z[1] = probe(w)
+```
+
+`RWProbe`{.firrtl} references to ports are not allowed on public-facing
+modules.
+
+#### Probes and Passive Types
+
+While `Probe`{.firrtl} inner types are passive, the type of the probed
+static reference is not required to be:
+
+```firrtl
+module Foo :
+  input x : {a: UInt, flip b: UInt}
+  output y : {a: UInt, flip b: UInt}
+  output xp : Probe<{a: UInt, b: UInt}> ; passive
+
+  wire p : {a: UInt, flip b: UInt} ; p is not passive
+  define xp = probe(p)
+  p <= x
+  y <= p
+```
+
+#### Exporting References to Nested Declarations
+
+Nested declarations (see [@sec:nested-declarations]) may be exported:
+
+```firrtl
+module RefProducer :
+  input a : UInt
+  input en : UInt<1>
+  output thereg : Probe<UInt>
+
+  when en :
+    reg myreg : UInt, clk
+    myreg <= a
+    define thereg = probe(myreg)
+```
+
+#### Forwarding References Upwards
+
+Define statements can be used to forward a child module's reference further up
+the hierarchy:
+
+```firrtl
+module Foo :
+  output p : Probe<UInt>
+  ; ...
+
+module Forward :
+  output p : Probe<UInt>
+
+  inst f of Foo
+  define p = f.p
+```
+
+Define statements may narrow a probe of an aggregate to a sub-element using
+static expression:
+
+```firrtl
+module Foo :
+  output p : Probe<UInt[2]>[2]
+  ; ...
+
+module Forward :
+  output p : Probe<UInt>
+
+  inst f of Foo
+  define p = f.p[0][1]
+```
+
+#### Forwarding References Downwards
+
+Define statements can also be used to forward references down the hierarchy
+using input reference-type ports, which are allowed but should be used
+carefully as they make it possible to express
+invalid reference paths.
+
+See [@sec:input-references] for more details, a small example is given below:
+
+```firrtl
+module UnusedInputRef :
+  input r : Probe<UInt<1>>
+
+module ForwardDownwards :
+  input in : UInt<1>
+
+  inst u of UnusedInputRef
+  define u.r = probe(in)
+```
+
+### Force and Release
+
+To override existing drivers for a `RWProbe`{.firrtl}, the `force`{.firrtl}
+statement is used, and released with `release`{.firrtl}.  Force statements are
+simulation-only constructs and may not be supported by all implementations.
+They are similar to the verification statements (e.g., `assert`{.firrtl}) in
+this regard.
+
+These are two variants of each, enumerated below:
+
+| Name            | Arguments                    | Argument Types                                                   |
+|-----------------|------------------------------|----------------------------------------                          |
+| force_initial   | (ref, val)                   | (`RWProbe<T>`{.firrtl}, T)                                       |
+| release_initial | (ref)                        | (`RWProbe<T>`{.firrtl})                                          |
+| force           | (clock, condition, ref, val) | (`Clock`{.firrtl}, `UInt<1>`{.firrtl}, `RWProbe<T>`{.firrtl}, T) |
+| release         | (clock, condition, ref)      | (`Clock`{.firrtl}, `UInt<1>`{.firrtl}, `RWProbe<T>`{.firrtl})    |
+
+Backends optionally generate corresponding constructs in the target language,
+or issue an warning.
+
+The following `AddRefs`{.firrtl} module is used in the examples that follow for
+each construct.
+
+```firrtl
+module AddRefs:
+  output a : RWProbe<UInt<2>>
+  output b : RWProbe<UInt<2>>
+  output c : RWProbe<UInt<2>>
+  output sum : UInt<3>
+
+  node x = Uint<2>(0)
+  node y : UInt<2>(0)
+  node z : UInt<2>(0)
+  sum <= add(x, add(y, z))
+
+  define a = rwprobe(x)
+  define b = rwprobe(y)
+  define c = rwprobe(z)
+```
+
+#### Initial Force and Initial Release
+
+These variants force and release continuously:
+
+Example:
+
+```firrtl
+module ForceAndRelease:
+  output o : UInt<3>
+
+  inst r of AddRefs
+  o <= r.sum
+
+  force_initial(r.a, 0)
+  force_initial(r.a, 1)
+  force_initial(r.b, 2)
+  force_initial(r.c, 3)
+  release_initial(r.c)
+```
+
+In this example, the output `o`{.firrtl} will be `3`.  Note that globally the
+last force statement overrides the others until another force or release
+including the target.
+
+Sample SystemVerilog output for the force and release statements would be:
+
+```SystemVerilog
+initial begin
+  force ForceAndRelease.AddRefs.x = 0;
+  force ForceAndRelease.AddRefs.x = 1;
+  force ForceAndRelease.AddRefs.y = 2;
+  force ForceAndRelease.AddRefs.z = 3;
+  release ForceAndRelease.AddRefs.z;
+end
+```
+
+The `force_initial`{.firrtl} and `release_initial`{.firrtl} statements may
+occur under `when`{.firrtl} blocks which becomes a check of the condition
+first.  Note that this condition is only checked once and changes to it
+afterwards are irrelevant, and if executed the force will
+continue to be active.  For more control over their behavior, the other
+variants should be used.  Example:
+
+```firrtl
+when c : force_initial(ref, x)
+
+would become:
+```systemverilog
+initial if (c) force a.b = x;
+```
+
+#### Force and Release
+
+These more detailed variants allow specifying a clock and condition for when
+activating the force or release behavior continuously:
+
+```firrtl
+module ForceAndRelease:
+  input a: UInt<2>
+  input clock : Clock
+  input cond : UInt<1>
+  output o : UInt<3>
+
+  inst r of AddRefs
+  o <= r.sum
+
+  force(clock, c, r.a, a)
+  release(clock, not(c), r.a)
+```
+
+Which at the positive edge of `clock`{.firrtl} will either force or release
+`AddRefs.x`{.firrtl}.  Note that once active, these remain active regardless of
+the condition, until another force or release.
+
+Sample SystemVerilog output:
+
+```SystemVerilog
+always @(posedge clock) begin
+  if (c)
+    force ForceAndRelease.AddRefs.x = a;
+  else
+    release ForceAndRelease.AddRefs.x;
+end
+```
+
+Condition is checked in procedural block before the force, as shown above.
+When placed under `when`{.firrtl} blocks, condition is mixed in as with other
+statements (e.g., `assert`{.firrtl}).
+
+#### Non-Passive Force Target
+
+Force on a non-passive bundle drives in the direction of each field's
+orientation.
+
+Example:
+
+```firrtl
+module Top:
+  input x : {a: UInt, flip b: UInt}
+  output y : {a: UInt, flip b: UInt}
+
+  inst d of DUT
+  d.x <= x
+  y <= d.y
+
+  wire val : {a: UInt<2>, b: UInt<2>}
+  val.a <= UInt<2>(1)
+  val.b <= UInt<2>(2)
+
+  ; Force takes a RWProbe and overrides the target with 'val'.
+  force(d.xp, val)
+
+module DUT :
+  input x : {a: UInt, flip b: UInt}
+  output y : {a: UInt, flip b: UInt}
+  output xp : RWProbe<{a: UInt, b: UInt}>
+
+  ; Force drives p.a, p.b, y.a, and x.b, but not y.b and x.a
+  wire p : {a: UInt, flip b: UInt}
+  define xp = rwprobe(p)
+  p <= x
+  y <= p
+```
+
 # Expressions
 
 FIRRTL expressions are used for creating literal unsigned and signed integers,
 for referring to a declared circuit component, for statically and dynamically
-accessing a nested element within a component, for creating multiplexers, and
-for performing primitive operations.
+accessing a nested element within a component, for creating multiplexers, for
+performing primitive operations, and for reading a remote reference to a probe.
 
 ## Unsigned Integers
 
@@ -1716,6 +2266,16 @@ In the rest of the document, for brevity, the names of components will be used
 to refer to a reference expression to that component. Thus, the above example
 will be rewritten as "the port `in`{.firrtl} is connected to the port
 `out`{.firrtl}".
+
+### Static Reference Expressions
+
+Static references start with an identifier, optionally followed by sub-fields
+or sub-indices selecting a particular sub-element.  Sub-accesses are not
+allowed.
+
+Define statements must have static references as their target, and their source
+must be either a static reference or a probe expression whose argument
+is a static reference.
 
 ## Sub-fields
 
@@ -1956,6 +2516,82 @@ asClock(x)
 
 [@sec:primitive-operations] will describe the format and semantics of each
 primitive operation.
+
+## Reading Probe References
+
+Probes are read using the `read`{.firrtl} operation.
+
+Read expressions have source flow and can be connected to other components:
+
+```firrtl
+module Foo :
+  output p : Probe<UInt>
+  ; ...
+
+module Bar :
+  output x : UInt
+
+  inst f of Foo
+  x <= read(f.p) ; indirectly access the probed data
+```
+
+Indexing statically (sub-field, sub-index) into a probed value is allowed as
+part of the read:
+
+```firrtl
+module Foo :
+  output p : Probe<{a: UInt, b: UInt}>
+  ; ...
+
+module Bar :
+  output x : UInt
+
+  inst f of Foo
+  x <= read(f.p.b) ; indirectly access the probed data
+```
+
+Read operations can be used anywhere a signal of the same underlying
+type can be used, such as the following:
+
+```firrtl
+  x <= add(read(f.p).a, read(f.p).b)
+```
+
+The source of the probe must reside at or below the point of the
+`read`{.firrtl} expression in the design hierarchy.  See
+[@sec:invalid-input-reference] for an example of an invalid `read`{.firrtl} of
+an input reference.
+
+## Probe
+
+Probe references are generated with probe expressions.
+
+The probe expression creates a reference to a read-only or force-able view of
+the data underlying the specified reference expression.
+
+The type of the produced probe reference is always passive, but the probed
+expression may not be.
+
+Probed memories produce a vector of references to their data.
+
+There are two probe varieties: `probe`{.firrtl} and `rwprobe`{.firrtl} for
+producing probes of type `Probe`{.firrtl} and `RWProbe`{.firrtl}, respectively.
+
+The following example exports a probe reference to a port:
+
+```firrtl
+module MyModule :
+  input in: UInt
+  output r : Probe<UInt>
+
+  define r = probe(in)
+```
+
+The probed expression must be a static reference.
+
+See [@sec:probe-types;@sec:probe] for more details on probe references and
+their use.
+
 
 # Primitive Operations {#sec:primitive-operations}
 
@@ -2770,8 +3406,9 @@ type_ground = "Clock" | "Reset" | "AsyncReset"
             | ( "UInt" | "SInt" | "Analog" ) , [ width ] ;
 type_aggregate = "{" , field , { field } , "}"
                | type , "[" , int , "]" ;
+type_ref = ( "Probe" | "RWProbe" ) , "<", type , ">" ;
 field = [ "flip" ] , id , ":" , type ;
-type = [ "const" ], ( type_ground | type_aggregate ) ;
+type = ( [ "const" ] , ( type_ground | type_aggregate ) ) | type_ref ;
 
 (* Primitive operations *)
 primop_2expr_keyword =
@@ -2802,11 +3439,15 @@ expr =
     ( "UInt" | "SInt" ) , [ width ] , "(" , ( int ) , ")"
   | reference
   | "mux" , "(" , expr , "," , expr , "," , expr , ")"
+  | "read" , "(" , static_reference , ")"
   | primop ;
-reference = id
-          | reference , "." , id
-          | reference , "[" , int , "]"
+static_reference = id
+                 | static_reference , "." , id
+                 | static_reference , "[" , int , "]" ;
+reference = static_reference
           | reference , "[" , expr , "]" ;
+ref_expr = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
+           | static_reference ;
 
 (* Memory *)
 ruw = ( "old" | "new" | "undefined" ) ;
@@ -2820,6 +3461,13 @@ memory = "mem" , id , ":" , [ info ] , newline , indent ,
            { "writer" , "=>" , id , newline } ,
            { "readwriter" , "=>" , id , newline } ,
          dedent ;
+
+(* Force and Release *)
+force_release =
+    "force_initial" , "(" , ref_expr , "," , expr , ")"
+  | "release_initial" , "(" , ref_expr , ")"
+  | "force" , "(" , expr , "," , expr , "," , ref_expr , "," , expr , ")"
+  | "release" , "(" , expr , "," , expr , "," , ref_expr , ")" ;
 
 (* Statements *)
 statement = "wire" , id , ":" , type , [ info ]
@@ -2839,7 +3487,9 @@ statement = "wire" , id , ":" , type , [ info ]
           | "stop(" , expr , "," , expr , "," , int , ")" , [ info ]
           | "printf(" , expr , "," , expr , "," , string ,
             { expr } , ")" , [ ":" , id ] , [ info ]
-          | "skip" , [ info ] ;
+          | "skip" , [ info ]
+          | "define" , static_reference , "=" , ref_expr , [ info ]
+          | force_release , [ info ] ;
 
 (* Module definitions *)
 port = ( "input" | "output" ) , id , ":": , type , [ info ] ;
@@ -2851,6 +3501,8 @@ extmodule = "extmodule" , id , ":" , [ info ] , newline , indent ,
               { port , newline } ,
               [ "defname" , "=" , id , newline ] ,
               { "parameter" , id , "=" , ( string | int ) , newline } ,
+              { "ref" , static_reference , "is" ,
+                '"' , static_reference , '"' , newline } ,
             dedent ;
 intmodule = "intmodule" , id , ":" , [ info ] , newline , indent ,
               { port , newline } ,

--- a/spec.md
+++ b/spec.md
@@ -578,9 +578,9 @@ underlying circuit constructs they originate from, captured using
 possible, as read-only probes impose fewer limitations and are more amenable to
 optimization.
 
-Probe references must always be able to be statically traced to their target, or to
-an external module's output reference.  This means no conditional connections
-via sub-accesses, multiplexers, or other means.
+Probe references must always be able to be statically traced to their target,
+or to an external module's output reference.  This means no conditional
+connections via sub-accesses, multiplexers, or other means.
 
 ### Probe Types
 
@@ -688,8 +688,8 @@ reference paths.  When probe references are used to access the underlying data
 statically known element at or below the point of that use, in all contexts.
 Support for other scenarios are allowed as determined by the implementation.
 
-Input probe references are not allowed on public-facing modules: e.g., the top module
-and external modules.
+Input probe references are not allowed on public-facing modules: e.g., the top
+module and external modules.
 
 Examples of input probe references follow.
 


### PR DESCRIPTION
## Summary

Introduce "reference types" for indirect access to FIRRTL constructs.

Add operations for generating probe references and using them to remotely access data (via XMR's).

## Motivation

Enable expressing XMR's, particularly testing/verification scenarios, with minimal impact on the generated design other than requiring visibility of the probed elements.  The goal is both testbench and design can be written in FIRRTL and have type-safe XMR's robust to hierarchy changes during compilation.

Second goal is to serve as pathway for producing resolved paths to signals for use in "raw" SV (e.g., testbench).  Specifically, supporting the ability to use SV "force" on a probe (`RWProbe<T>`) is a requirement.  These are typed differently as they cause much more conservative handling by the compiler.

## References aren't Hardware, Cannot be "Connect"ed

To ensure a valid hierarchical reference can be emitted, the target must be below the access point in the hierarchy, although implementations are open to support other scenarios as they see fit / make sense in the target language.

References are not hardware types and as a result are not usable in most places --  they're only allowed as/in module ports.  Additionally, similar to Analog,  while they may be used in aggregates for convenience/grouping they cannot be used as part of "connect"s and so when mixed with hardware data, the hardware fields need to be connected explicitly and appropriate routing statements used for the reference (`attach` for Analog).

References are routed through the design *statically*, using new "forward" statement and originating "export" statement.

To support XMR'ing + separate compilation, `extmodule` may optionally specify resolved paths for its output references.

## Example

An example demonstrating some features in the proposal, with possible output Verilog:

```scala
circuit Probe :
  module Child :
    input in : UInt<1>[2]
    output r : Probe<UInt<1>[2]>
    define r = probe(in)

  module Mid :
    input in : UInt<1>[2]
    output r : Probe<UInt<1>[2]>
    output r1 : Probe<UInt<1>>

    inst c of Child
    c.in <= in
    define r = c.r
    define r1 as c.r[1]

  module Probe :
    input in : UInt<1>[2]
    output r : Probe<UInt<1>[2]>
    output out : UInt<1>[2]
    output out_r1 : UInt<1>
    output out_r0_from_r : UInt<1>

    inst m of Mid
    m.in <= in
    define r = m.r

    out <= read(m.r)
    out_r1 <= read(m.r1)
    out_r0_from_r <= read(m.r[0])
```

Example output Verilog (no aggregate preservation, default):

```verilog
module Child(
  input in_0,
        in_1
);

endmodule

module Mid(
  input in_0,
        in_1
);

  Child c (
    .in_0 (in_0),
    .in_1 (in_1)
  );
endmodule

module Probe(
  input  in_0,
         in_1,
  output out_0,
         out_1,
         out_r1,
         out_r0_from_r
);

  Mid m (
    .in_0 (in_0),
    .in_1 (in_1)
  );
  assign out_0 = Probe.m.c.in_0;
  assign out_1 = Probe.m.c.in_1;
  assign out_r1 = Probe.m.c.in_1;
  assign out_r0_from_r = Probe.m.c.in_0;
endmodule
```

See spec.md diff for additional FIRRTL examples.

## Implementation and Related

FIRRTL References are inspired by and mostly map to CIRCT's `firrtl.ref` type and related operations (`ref.send`, `ref.resolve`) but the proposed references are designed to overcome some limitations with `firrtl.ref` and for better composition with existing FIRRTL / friendliness to generation.

CIRCT implementation of proposed references is underway.