### PR TITLE
[patch] Add syntax support for type modifiers (e.g., const).

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -28,6 +28,9 @@
       <item>Reset</item>
       <item>AsyncReset</item>
     </list>
+    <list name="typemodifiers">
+      <item>const</item>
+    </list>
     <list name="conditionals">
       <item>when</item>
       <item>else</item>
@@ -83,6 +86,7 @@
       <context name="Normal Text" attribute="ID" lineEndContext="#pop">
         <keyword attribute="Keyword" context="#stay" String="keywords" />
         <keyword attribute="Keyword" context="type" String="types" />
+        <keyword attribute="Keyword" context="#stay" String="typemodifiers" />
         <keyword attribute="Structure" context="#stay" String="structure" />
         <keyword attribute="PrimOp" context="#stay" String="primops" />
         <keyword attribute="Conditional" context="#stay" String="conditionals" />
@@ -142,6 +146,7 @@
       <context name="field" attribute="ID" lineEndContext="#stay">
         <StringDetect String="flip" attribute="Keyword" context="#stay"/>
         <keyword String="types" attribute="Keyword" context="type"/>
+        <keyword String="typemodifiers" attribute="Keyword" context="#stay"/>
         <DetectChar char="{" attribute="Separator" context="field"/>
         <DetectChar char="}" attribute="Separator" context="#pop"/>
         <AnyChar String=":," attribute="Separator" context="#stay"/>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -13,6 +13,7 @@ revisionHistory:
     - Define constant type modifier.
     - Remove stray language leftover from removing conditionally valid.
     - Render inline annotations as JSON, fix typo in example.
+    - Fix rendering of type modifiers (const) in document.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.2.0


### PR DESCRIPTION
Fix rendering const types in PDF.