### PR TITLE
[patch] Render inline annotations as JSON, fix typo in example

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -97,6 +97,7 @@
         <DetectChar char="&quot;" attribute="String" context="string"/>
         <StringDetect String="reg" attribute="Keyword" context="register"/>
         <StringDetect String="mem" attribute="Keyword" context="memoryFirst"/>
+        <StringDetect String="%[" attribute="Operator" context="inlineannotation"/>
       </context>
       <context name="memoryFirst" attribute="ID" lineEndContext="#pop!memory">
       </context>
@@ -145,6 +146,10 @@
         <DetectChar char="}" attribute="Separator" context="#pop"/>
         <AnyChar String=":," attribute="Separator" context="#stay"/>
         <DetectChar char= ";" context="comment" attribute="Comment"/>
+      </context>
+      <context name="inlineannotation" attribute="Operator" lineEndContext="#stay">
+        <DetectChar char="]" attribute="Operator" context="#pop"/>
+        <IncludeRules context="##JSON" includeAttrib="true"/>
       </context>
     </contexts>
     <itemDatas>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -12,6 +12,7 @@ revisionHistory:
     - Add Compiler Implementation Details documenting Lower Types pass
     - Define constant type modifier.
     - Remove stray language leftover from removing conditionally valid.
+    - Render inline annotations as JSON, fix typo in example.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.2.0

--- a/spec.md
+++ b/spec.md
@@ -2479,7 +2479,7 @@ circuit Foo: %[[
     "target":"~Foo|Baz"
   }
 ]]
-  module : Foo
+  module Foo :
   ; ...
 ```
 

--- a/spec.md
+++ b/spec.md
@@ -2465,8 +2465,8 @@ containing two annotations:
 ```
 
 Annotations may also be stored in-line along with the FIRRTL circuit by wrapping
-Annotation JSON in `%[ ... ]`.  The following shows the above annotation file
-stored in-line:
+Annotation JSON in `%[ ... ]`{.firrtl}.  The following shows the above
+annotation file stored in-line:
 
 ``` firrtl
 circuit Foo: %[[


### PR DESCRIPTION
Apparently we can bounce to other syntax definitions, use that to make inline annotations render nicely.

Also fix unstyled inline anno while visiting.

Modeled this after https://github.com/KDE/syntax-highlighting/blob/2880570764a754bdf2ed402d6fd24024a35bf5bc/data/syntax/markdown.xml#L421 , seems to work for our use case.