### PR TITLE
[patch] Fix grammar for registers.

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -14,6 +14,7 @@ revisionHistory:
     - Remove stray language leftover from removing conditionally valid.
     - Render inline annotations as JSON, fix typo in example.
     - Fix rendering of type modifiers (const) in document.
+    - Fix grammar for registers.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 1.2.0

--- a/spec.md
+++ b/spec.md
@@ -2824,7 +2824,9 @@ memory = "mem" , id , ":" , [ info ] , newline , indent ,
 (* Statements *)
 statement = "wire" , id , ":" , type , [ info ]
           | "reg" , id , ":" , type , expr ,
-            [ "(with: {reset => (" , expr , "," , expr ")})" ] , [ info ]
+            [ "with" , ":" , "(" , "reset" , "=>" ,
+              "(" , expr , "," , expr , ")", ")" ] ,
+            [ info ]
           | memory
           | "inst" , id , "of" , id , [ info ]
           | "node" , id , "=" , expr , [ info ]


### PR DESCRIPTION
* Missing comma between reset value and closing paren.
* Wrong punctuation ("{" vs "(" around reset)
* Drop outer parentheses around "with :" portion.
* Break string literal into tokens. (Generally useful, but specifically support the whitespace variations in document such as "with:" vs "with :")