### PR TITLE
[patch] Clarify Int/String Types, clarify SE-Ints

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -4,6 +4,7 @@ revisionHistory:
   # populated using the "version" that the Makefile grabs from git.  Notable
   # additions to the specification should append entries here.
   thisVersion:
+    - Clarify int/string types and their allowed usage.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 2.0.0


### PR DESCRIPTION
Add language that explicitly defines literal types:

  1. Integer literals
  2. String literals
  3. Raw String literals
  4. String-encoded integer literals

This only clarifies existing behavior which was left ambiguous or documented in different locations in the spec.

Define that string-encoded integer literals can be used any place that an integer literal can except where specified otherwise.  This is used to differentiate where an external module parameter that looks like a string-encoded integer literal is still a string.  This is also used to preserve the existing SFC behavior where a string-encoded integer literal is not allowed to be used for memory integers.

Notably, this is enshrining the fact that you can do things today like:

```
circuit Foo:
  module Foo:
    input clock: Clock
    input a: UInt<"hF">["o10"]
    output b: UInt<"b1111">[8]

    b <= a
```