### PR TITLE
[major] Only allow se-ints in hardware literals, change se-ints to rints

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -4,6 +4,8 @@ revisionHistory:
   # populated using the "version" that the Makefile grabs from git.  Notable
   # additions to the specification should append entries here.
   thisVersion:
+    - Restrict string-encoded integers to only being usable in the construction
+      of hardware literals.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 2.0.1

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -4,9 +4,11 @@ revisionHistory:
   # populated using the "version" that the Makefile grabs from git.  Notable
   # additions to the specification should append entries here.
   thisVersion:
-    - Clarify int/string types and their allowed usage.
   # Information about the old versions.  This should be static.
   oldVersions:
+    - version: 2.0.1
+      changes:
+        - Clarify int/string types and their allowed usage.
     - version: 2.0.0
       changes:
         - Remove Fixed Point Types.

--- a/spec.md
+++ b/spec.md
@@ -289,9 +289,6 @@ Foo #(
 ) bar();
 ```
 
-A parameter that is a string-encoded integer literal is treated as a string
-literal.
-
 ## Implementation Defined Modules (Intrinsics)
 
 Intrinsic modules are modules which represent implementation-defined,
@@ -317,9 +314,6 @@ intmodule MyIntrinsicModule_xhello_y64 :
 
 The types of intrinsic module parameters may only be literal integers or
 string literals.
-
-A parameter that is a string-encoded integer literal is treated as a string
-literal.
 
 # Literals
 
@@ -375,8 +369,8 @@ The following string-encoded integer literals all have the value `-42`:
 "h-2a"
 ```
 
-String-encoded integer literals are usable in any place where an integer would
-be unless explicitly disallowed.
+String-encoded integer literals are only usable when constructing hardware
+integer literals.  Any use in place of an integer is disallowed.
 
 # Types
 
@@ -1654,9 +1648,6 @@ by the following parameters.
 
 6.  A read-under-write flag indicating the behavior when a memory location is
     written to while a read to that location is in progress.
-
-Integer literals for the number of elements and the read/write latencies _may
-not be string-encoded integer literals_.
 
 The following example demonstrates instantiating a memory containing 256 complex
 numbers, each with 16-bit signed integer fields for its real and imaginary
@@ -3495,9 +3486,6 @@ int_se =
   | '"' , "o" , [ "-" ] , digit_oct , { digit_oct } , '"'
   | '"' , "h" , [ "-" ] , digit_hex , { digit_hex } , '"' ;
 
-(* An Integer or String-encoded Integer Literal *)
-int_any = int | int_se ;
-
 (* String Literals *)
 string = ? a string ? ;
 string_raw = "'" , string , "'" ;
@@ -3518,11 +3506,11 @@ linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;
 info = "@" , "[" , { string , " " , linecol } , "]" ;
 
 (* Type definitions *)
-width = "<" , int_any , ">" ;
+width = "<" , int , ">" ;
 type_ground = "Clock" | "Reset" | "AsyncReset"
             | ( "UInt" | "SInt" | "Analog" ) , [ width ] ;
 type_aggregate = "{" , field , { field } , "}"
-               | type , "[" , int_any , "]" ;
+               | type , "[" , int , "]" ;
 type_ref = ( "Probe" | "RWProbe" ) , "<", type , ">" ;
 field = [ "flip" ] , id , ":" , type ;
 type = ( [ "const" ] , ( type_ground | type_aggregate ) ) | type_ref ;
@@ -3544,23 +3532,23 @@ primop_1expr =
 primop_1expr1int_keyword =
     "pad" | "shl" | "shr" | "head" | "tail" ;
 primop_1expr1int =
-    primop_1exrp1int_keyword , "(", expr , "," , int_any , ")" ;
+    primop_1exrp1int_keyword , "(", expr , "," , int , ")" ;
 primop_1expr2int_keyword =
     "bits" ;
 primop_1expr2int =
-    primop_1expr2int_keyword , "(" , expr , "," , int_any , "," , int_any , ")" ;
+    primop_1expr2int_keyword , "(" , expr , "," , int , "," , int , ")" ;
 primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
 
 (* Expression definitions *)
 expr =
-    ( "UInt" | "SInt" ) , [ width ] , "(" , int_any , ")"
+    ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | int_se ) , ")"
   | reference
   | "mux" , "(" , expr , "," , expr , "," , expr , ")"
   | "read" , "(" , static_reference , ")"
   | primop ;
 static_reference = id
                  | static_reference , "." , id
-                 | static_reference , "[" , int_any , "]" ;
+                 | static_reference , "[" , int , "]" ;
 reference = static_reference
           | reference , "[" , expr , "]" ;
 ref_expr = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
@@ -3601,7 +3589,7 @@ statement = "wire" , id , ":" , type , [ info ]
           | "when" , expr , ":" [ info ] , newline , indent ,
               { statement } ,
             dedent , [ "else" , ":" , indent , { statement } , dedent ]
-          | "stop(" , expr , "," , expr , "," , int_any , ")" , [ info ]
+          | "stop(" , expr , "," , expr , "," , int , ")" , [ info ]
           | "printf(" , expr , "," , expr , "," , string ,
             { expr } , ")" , [ ":" , id ] , [ info ]
           | "skip" , [ info ]

--- a/spec.md
+++ b/spec.md
@@ -341,35 +341,35 @@ a trailing `'`{.firrtl}.  The following is an example of a raw string literal:
 'world'
 ```
 
-## String-encoded Integer Literal
+## Radix-specified Integer Literal
 
-A string-encoded integer literal is a special string literal with one of the
+A radix-specified integer literal is a special integer literal with one of the
 following leading characters to indicate the numerical encoding:
 
 - `b`{.firrtl} -- for representing binary numbers
 - `o`{.firrtl} -- for representing octal numbers
 - `h`{.firrtl} -- for representing hexadecimal numbers
 
-Signed string-encoded integer literals have their sign following the leading
+Signed radix-specified integer literals have their sign following the leading
 encoding character.
 
 The following string-encoded integer literals all have the value `42`:
 
 ``` firrtl
-"b101010"
-"o52"
-"h2a"
+b101010
+o52
+h2a
 ```
 
 The following string-encoded integer literals all have the value `-42`:
 
 ``` firrtl
-"b-101010"
-"o-52"
-"h-2a"
+b-101010
+o-52
+h-2a
 ```
 
-String-encoded integer literals are only usable when constructing hardware
+Radix-encoded integer literals are only usable when constructing hardware
 integer literals.  Any use in place of an integer is disallowed.
 
 # Types
@@ -2316,7 +2316,7 @@ operations, and for reading a remote reference to a probe.
 ## Constant Integer Expressions
 
 A constant unsigned or signed integer expression can be created from an integer
-literal or string-encoded integer literal.  An optional positive bit width may
+literal or radix-specified integer literal.  An optional positive bit width may
 be specified. Constant integer expressions are of constant type.  All of the
 following examples create a 10-bit unsigned constant integer expressions
 representing the number `42`:
@@ -2343,7 +2343,7 @@ UInt("h2a")
 ```
 
 Signed constant integer expressions may be created from a signed integer literal
-or signed string-encoded integer literal.  All of the following examples create
+or signed radix-encoded integer literal.  All of the following examples create
 a 10-bit signed hardware integer representing the number `-42`:
 
 ``` firrtl
@@ -3480,11 +3480,11 @@ digit_hex = digit_dec
           | "a" | "b" | "c" | "d" | "e" | "f" ;
 int = [ "-" ] , digit_bin , { digit_bin } ;
 
-(* String-encoded Integer Literals *)
-int_se =
-    '"' , "b" , [ "-" ] , digit_bin , { digit_bin } , '"'
-  | '"' , "o" , [ "-" ] , digit_oct , { digit_oct } , '"'
-  | '"' , "h" , [ "-" ] , digit_hex , { digit_hex } , '"' ;
+(* Radix-specified Integer Literals *)
+rint =
+    "b" , [ "-" ] , digit_bin , { digit_bin }
+  | "o" , [ "-" ] , digit_oct , { digit_oct }
+  | "h" , [ "-" ] , digit_hex , { digit_hex } ;
 
 (* String Literals *)
 string = ? a string ? ;
@@ -3541,7 +3541,7 @@ primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
 
 (* Expression definitions *)
 expr =
-    ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | int_se ) , ")"
+    ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | rint ) , ")"
   | reference
   | "mux" , "(" , expr , "," , expr , "," , expr , ")"
   | "read" , "(" , static_reference , ")"


### PR DESCRIPTION
Restrict the usage of string-encoded integer literals to only being allowable used in the construction of hardware integer literals.

Change string-encoded integer literals to radix-specified integer literals. E.g., this changes:

```
"b10101"
```

To:

```
b10101
```

Radix-specified integer literals are still restricted to only being used in hardware integer literals. Signed values are still allowed.

This is currently stacked on #86.