### PR TITLE
[major] Only allow se-ints in hardware literals, change se-ints to radix-encoded ints

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -17,6 +17,7 @@ revisionHistory:
       - Add type alias
       - Restrict string-encoded integers to only being usable in the
         construction of hardware literals.
+      - Change string-encoded integers to radix-encoded integers.
     abi:
       - Initial ABI description.
   # Information about the old versions.  This should be static.

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -15,6 +15,8 @@ revisionHistory:
       - Add enumeration types, match statements, and enumeration expressions
       - Fixup probe endpoint and non-passive force examples.
       - Add type alias
+      - Restrict string-encoded integers to only being usable in the
+        construction of hardware literals.
     abi:
       - Initial ABI description.
   # Information about the old versions.  This should be static.

--- a/spec.md
+++ b/spec.md
@@ -308,35 +308,38 @@ a trailing `'`{.firrtl}.  The following is an example of a raw string literal:
 'world'
 ```
 
-## String-encoded Integer Literal
+## Radix-specified Integer Literal
 
-A string-encoded integer literal is a special string literal with one of the
+A radix-specified integer literal is a special integer literal with one of the
 following leading characters to indicate the numerical encoding:
 
-- `b`{.firrtl} -- for representing binary numbers
-- `o`{.firrtl} -- for representing octal numbers
-- `h`{.firrtl} -- for representing hexadecimal numbers
+- `0b`{.firrtl} -- for representing binary numbers
+- `0o`{.firrtl} -- for representing octal numbers
+- `0d`{.firrtl} -- for representing decimal numbers
+- `0h`{.firrtl} -- for representing hexadecimal numbers
 
-Signed string-encoded integer literals have their sign following the leading
+Signed radix-specified integer literals have their sign following the leading
 encoding character.
 
 The following string-encoded integer literals all have the value `42`:
 
 ``` firrtl
-"b101010"
-"o52"
-"h2a"
+0b101010
+0o52
+0d42
+0h2a
 ```
 
 The following string-encoded integer literals all have the value `-42`:
 
 ``` firrtl
-"b-101010"
-"o-52"
-"h-2a"
+-0b101010
+-0o52
+-0d42
+-0h2a
 ```
 
-String-encoded integer literals are only usable when constructing hardware
+Radix-encoded integer literals are only usable when constructing hardware
 integer literals.  Any use in place of an integer is disallowed.
 
 # Types
@@ -2395,7 +2398,7 @@ operations, and for reading a remote reference to a probe.
 ## Constant Integer Expressions
 
 A constant unsigned or signed integer expression can be created from an integer
-literal or string-encoded integer literal.  An optional positive bit width may
+literal or radix-specified integer literal.  An optional positive bit width may
 be specified. Constant integer expressions are of constant type.  All of the
 following examples create a 10-bit unsigned constant integer expressions
 representing the number `42`:
@@ -2422,7 +2425,7 @@ UInt("h2a")
 ```
 
 Signed constant integer expressions may be created from a signed integer literal
-or signed string-encoded integer literal.  All of the following examples create
+or signed radix-encoded integer literal.  All of the following examples create
 a 10-bit signed hardware integer representing the number `-42`:
 
 ``` firrtl
@@ -3638,11 +3641,12 @@ digit_hex = digit_dec
           | "a" | "b" | "c" | "d" | "e" | "f" ;
 int = [ "-" ] , digit_bin , { digit_bin } ;
 
-(* String-encoded Integer Literals *)
-int_se =
-    '"' , "b" , [ "-" ] , digit_bin , { digit_bin } , '"'
-  | '"' , "o" , [ "-" ] , digit_oct , { digit_oct } , '"'
-  | '"' , "h" , [ "-" ] , digit_hex , { digit_hex } , '"' ;
+(* Radix-specified Integer Literals *)
+rint =
+    [ "-" ] , "0b" , digit_bin , { digit_bin }
+  | [ "-" ] , "0o" , digit_oct , { digit_oct }
+  | [ "-" ] , "0d" , digit_oct , { digit_dec }
+  | [ "-" ] , "0h" , digit_hex , { digit_hex } ;
 
 (* String Literals *)
 string = ? a string ? ;
@@ -3709,7 +3713,7 @@ primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
 
 (* Expression definitions *)
 expr =
-    ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | int_se ) , ")"
+    ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | rint ) , ")"
   | type_enum , "(" , id , [ "," , expr ] , ")"
   | reference
   | "mux" , "(" , expr , "," , expr , "," , expr , ")"

--- a/spec.md
+++ b/spec.md
@@ -256,9 +256,6 @@ Foo #(
 ) bar();
 ```
 
-A parameter that is a string-encoded integer literal is treated as a string
-literal.
-
 ## Implementation Defined Modules (Intrinsics)
 
 Intrinsic modules are modules which represent implementation-defined,
@@ -284,9 +281,6 @@ intmodule MyIntrinsicModule_xhello_y64 :
 
 The types of intrinsic module parameters may only be literal integers or
 string literals.
-
-A parameter that is a string-encoded integer literal is treated as a string
-literal.
 
 # Literals
 
@@ -342,8 +336,8 @@ The following string-encoded integer literals all have the value `-42`:
 "h-2a"
 ```
 
-String-encoded integer literals are usable in any place where an integer would
-be unless explicitly disallowed.
+String-encoded integer literals are only usable when constructing hardware
+integer literals.  Any use in place of an integer is disallowed.
 
 # Types
 
@@ -613,7 +607,7 @@ The variant types of an enumeration must all be passive and cannot contain
 analog or probe types.
 
 In the following example, the first variant has the tag `a`{.firrtl} with type
-`UInt<8>`{.firrtl}, and the second variant has the tag `b`{.firrtl} with type 
+`UInt<8>`{.firrtl}, and the second variant has the tag `b`{.firrtl} with type
 `UInt<16>`{.firrtl}.
 
 ``` firrtl
@@ -1733,9 +1727,6 @@ by the following parameters.
 
 6.  A read-under-write flag indicating the behavior when a memory location is
     written to while a read to that location is in progress.
-
-Integer literals for the number of elements and the read/write latencies _may
-not be string-encoded integer literals_.
 
 The following example demonstrates instantiating a memory containing 256 complex
 numbers, each with 16-bit signed integer fields for its real and imaginary
@@ -3653,9 +3644,6 @@ int_se =
   | '"' , "o" , [ "-" ] , digit_oct , { digit_oct } , '"'
   | '"' , "h" , [ "-" ] , digit_hex , { digit_hex } , '"' ;
 
-(* An Integer or String-encoded Integer Literal *)
-int_any = int | int_se ;
-
 (* String Literals *)
 string = ? a string ? ;
 string_dq = '"' , string , '"' ;
@@ -3680,13 +3668,13 @@ lineinfo = string, " ", linecol
 info = "@" , "[" , lineinfo, { ",", lineinfo }, "]" ;
 
 (* Type definitions *)
-width = "<" , int_any , ">" ;
+width = "<" , int , ">" ;
 type_ground = "Clock" | "Reset" | "AsyncReset"
             | ( "UInt" | "SInt" | "Analog" ) , [ width ] ;
 type_enum = "{|" , { field_enum } , "|}" ;
 field_enum = id, [ ":" , type_simple_child ] ;
 type_aggregate = "{" , field , { field } , "}"
-               | type , "[" , int_any , "]" ;
+               | type , "[" , int , "]" ;
 type_ref = ( "Probe" | "RWProbe" ) , "<", type , ">" ;
 field = [ "flip" ] , id , ":" , type ;
 type_simple_child = type_ground | type_enum | type_aggregate | id ;
@@ -3712,16 +3700,16 @@ primop_1expr =
 primop_1expr1int_keyword =
     "pad" | "shl" | "shr" | "head" | "tail" ;
 primop_1expr1int =
-    primop_1exrp1int_keyword , "(", expr , "," , int_any , ")" ;
+    primop_1exrp1int_keyword , "(", expr , "," , int , ")" ;
 primop_1expr2int_keyword =
     "bits" ;
 primop_1expr2int =
-    primop_1expr2int_keyword , "(" , expr , "," , int_any , "," , int_any , ")" ;
+    primop_1expr2int_keyword , "(" , expr , "," , int , "," , int , ")" ;
 primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
 
 (* Expression definitions *)
 expr =
-    ( "UInt" | "SInt" ) , [ width ] , "(" , int_any , ")"
+    ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | int_se ) , ")"
   | type_enum , "(" , id , [ "," , expr ] , ")"
   | reference
   | "mux" , "(" , expr , "," , expr , "," , expr , ")"
@@ -3729,7 +3717,7 @@ expr =
   | primop ;
 static_reference = id
                  | static_reference , "." , id
-                 | static_reference , "[" , int_any , "]" ;
+                 | static_reference , "[" , int , "]" ;
 reference = static_reference
           | reference , "[" , expr , "]" ;
 ref_expr = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
@@ -3774,7 +3762,7 @@ statement =
     indent , statement, { statement } , dedent ,
     [ "else" , ":" , indent , statement, { statement } , dedent ]
   | "match" , expr , ":" , [ info ] , newline ,
-    [ indent , { id , [ "(" , id , ")" ] , ":" , newline , 
+    [ indent , { id , [ "(" , id , ")" ] , ":" , newline ,
     [ indent , { statement } , dedent ] } , dedent ]
   | "stop(" , expr , "," , expr , "," , int , ")" , [ info ]
   | "printf(" , expr , "," , expr , "," , string_dq ,


### PR DESCRIPTION
Restrict the usage of string-encoded integer literals to only being
allowable used in the construction of hardware integer literals.

Change string-encoded integer literals to radix-specified integer literals.
E.g., make the following change:

"b10101" to 0b01010

Remove string-encoded integer literals.  Continue to disallow the usage of
radix-specified integer literals in any location other than hardware integer
literal construction.