### PR TITLE
[patch] Tweak read grammar to allow read(probe(x)) as in examples.

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -7,6 +7,7 @@ revisionHistory:
     - Fix typos in force/release examples, force takes expr not int literal.
     - Delineate string and single-quoted/double-quoted string in grammar.
   # Information about the old versions.  This should be static.
+   - Tweak grammar of 'read' to support 'read(probe(x))' as in examples.
   oldVersions:
     - version: 2.0.1
       changes:

--- a/spec.md
+++ b/spec.md
@@ -3557,7 +3557,7 @@ expr =
     ( "UInt" | "SInt" ) , [ width ] , "(" , int_any , ")"
   | reference
   | "mux" , "(" , expr , "," , expr , "," , expr , ")"
-  | "read" , "(" , static_reference , ")"
+  | "read" , "(" , ref_expr , ")"
   | primop ;
 static_reference = id
                  | static_reference , "." , id


### PR DESCRIPTION
This isn't really generally useful but might as well allow it as it's useful for examples (such as those in spec already!).

Note you still can't `read(probe(x).y)` but not worth allowing when you might as well `read(probe(x.y))`.