### PR TITLE
[patch] Simple syntax tree fixes

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -4,6 +4,8 @@ revisionHistory:
   # populated using the "version" that the Makefile grabs from git.  Notable
   # additions to the specification should append entries here.
   thisVersion:
+    - Add 'asAsyncReset' to primop_1expr_keyword in "FIRRTL Language Definition"
+    - Fix grammar for force_release statements
 
   # Information about the old versions.  This should be static.
   oldVersions:

--- a/spec.md
+++ b/spec.md
@@ -3637,7 +3637,7 @@ statement = "wire" , id , ":" , type , [ info ]
             { expr } , ")" , [ ":" , id ] , [ info ]
           | "skip" , [ info ]
           | "define" , static_reference , "=" , ref_expr , [ info ]
-          | "force_release" , [ info ] ;
+          | force_release , [ info ]
           | "connect" , reference , "," , expr , [ info ]
           | "invalidate" , reference , [ info ]
 

--- a/spec.md
+++ b/spec.md
@@ -3567,7 +3567,7 @@ primop_2expr_keyword =
 primop_2expr =
     primop_2expr_keyword , "(" , expr , "," , expr ")" ;
 primop_1expr_keyword =
-    "asUInt" | "asSInt" | "asClock" | "cvt"
+    "asUInt" | "asSInt" | "asClock" | "asAsyncReset" | "cvt"
   | "neg"    | "not"
   | "andr"   | "orr"    | "xorr" ;
 primop_1expr =


### PR DESCRIPTION
- `asAsyncReset` was missing from `primop_1expr_keyword` (should have been in #25)
- `force_release` was incorrectly changed to a keyword in #95 