### PR TITLE
[major] Switch to 3.0.0 Syntaxes

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -13,8 +13,6 @@
       <item>defname</item>
       <item>parameter</item>
       <item>skip</item>
-      <item>is</item>
-      <item>invalid</item>
       <item>inst</item>
       <item>of</item>
       <item>wire</item>
@@ -114,7 +112,6 @@
         <Detect2Chars char="{" char1="|" context="field" attribute="Separator"/>
         <DetectChar char="{" context="field" attribute="Separator"/>
         <DetectChar char="`" context="field" attribute="ID"/>
-        <Detect2Chars char="&lt;" char1="=" attribute="Operator" context="#stay"/>
         <Detect2Chars char="&lt;" char1="-" attribute="Operator" context="#stay"/>
         <Detect2Chars char="=" char1="&gt;" attribute="Operator" context="#stay"/>
         <AnyChar String=":=.,()" attribute="Separator" context="#stay"/>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -18,6 +18,7 @@ revisionHistory:
       - Restrict string-encoded integers to only being usable in the
         construction of hardware literals.
       - Change string-encoded integers to radix-encoded integers.
+      - Remove legacy connect (`<=`) and invalidate (`is invalid`) syntax
     abi:
       - Initial ABI description.
   # Information about the old versions.  This should be static.


### PR DESCRIPTION
Remove the old connect ("<="), invalidation ("is invalid"), and register
with reset ("with: (reset => (resetSignal, resetValue))") syntaxes in
favor of syntax which does not require lookahead when parsing (connect and
invalidate) and simpler syntax (register with reset).  The new syntaxes,
which wer added as "alternative syntaxes" previously, are "connect",
"invalidate", and "regreset".

This is a major breaking change that becomes active in the 3.0.0 release.