### PR TITLE
[minor] Add "regreset" alternative syntax

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -117,6 +117,7 @@
         <AnyChar String=":=.,()" attribute="Separator" context="#stay"/>
         <DetectChar char="[" attribute="Operator" context="widthOrDepthOrLit"/>
         <DetectChar char="&quot;" attribute="String" context="string"/>
+        <StringDetect String="regreset" attribute="Keyword" context="register"/>
         <StringDetect String="reg" attribute="Keyword" context="register"/>
         <StringDetect String="mem" attribute="Keyword" context="memoryFirst"/>
         <StringDetect String="%[" attribute="Operator" context="inlineannotation"/>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -6,6 +6,7 @@ revisionHistory:
   thisVersion:
     - Add intrinsic modules to syntax highlighting
     - Add connect, invalidate to syntax highlighting
+    - Add alternative `regreset` syntax
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 2.2.0

--- a/spec.md
+++ b/spec.md
@@ -1249,6 +1249,21 @@ reg myreg: SInt, myclock with: (reset => (myreset, myinit))
 A register is initialized with an indeterminate value (see
 [@sec:indeterminate-values]).
 
+### Alternative Syntax
+
+A register with a reset may also be declared using an alternative syntax using
+the keyword `regreset`{.firrtl}.  Using this syntax, the operation takes four
+arguments: a type, a clock, a reset, and a reset value.  This syntax will become
+mandatory in the 3.0.0 FIRRTL specification.
+
+``` firrtl
+wire clock: Clock
+wire reset: UInt<1>
+wire resetValue: UInt<8>(0)
+regreset a: UInt<8>, clock, reset, resetValue
+; equivalent to reg a: UInt<8>, clock with: (reset => (reset, resetValue))
+```
+
 ## Invalidates
 
 An invalidate statement is used to indicate that a circuit component contains
@@ -3671,6 +3686,8 @@ statement =
     [ "with" , ":" , "(" , "reset" , "=>" ,
       "(" , expr , "," , expr , ")", ")" ] ,
     [ info ]
+  | "regreset" , id , ":" , type , "," , expr , "," , expr , "," , expr ,
+    [info]
   | memory
   | "inst" , id , "of" , id , [ info ]
   | "node" , id , "=" , expr , [ info ]


### PR DESCRIPTION
Add alternative syntax for specifying a register with a reset.  This is done to simplify parsing, readability, and writability.  This also brings the register more in line with other FIRRTL operations.

The new syntax looks like:

    regreset a: UInt<8>, clk, rst, init

The old syntax that this is an alternative to is:

    reg a: UInt<8>, clk with: (reset => (rst, init))

This syntax is intended to be introduced in the v2.3.0 minor release and made mandatory in the v3.0.0 release.

---

An alternative to this syntax would be to use:

    reg a: UInt<8>, clk, rst, init

I didn't do this as it seems easier to just use a new keyword as opposed to making `reg` variadic.