### PR TITLE
[major] Require Bundle fields are legal IDs

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -584,7 +584,8 @@ UInt<16>[10][20]
 ### Bundle Types
 
 A bundle type is used to express a collection of nested and named types.  All
-fields in a bundle type must have a given name, and type.
+fields in a bundle type must have a given name, and type.  All fields must be
+legal identifiers.
 
 The following is an example of a possible type for representing a complex
 number. It has two fields, `real`{.firrtl}, and `imag`{.firrtl}, both 10-bit


### PR DESCRIPTION
Change the spec to require that Bundle fields are legal identifiers. Currently, the SFC has historically accepted anything, including numbers for fields.  This stems from the MixedVec Chisel utility which emits numeric fields.  Change this to make lexing FIRRTL easier.  Currently, there is extreme ambiguity for something like "0.0".  This could be either a subfield or a floating point number.  By restricting subfields to require legal identifiers, this becomes illegal and the ambiguity is resolved.

Note: the EBNF description is already correct here.