### PR TITLE
[major] Add literal identifiers, e.g., `0`

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -111,6 +111,7 @@
         <Detect2Chars char="(" char1="*" attribute="Info" context="info"/>
         <DetectChar char= ";" context="comment" attribute="Comment"/>
         <DetectChar char="{" context="field" attribute="Separator"/>
+        <DetectChar char="`" context="field" attribute="ID"/>
         <Detect2Chars char="&lt;" char1="=" attribute="Operator" context="#stay"/>
         <Detect2Chars char="&lt;" char1="-" attribute="Operator" context="#stay"/>
         <Detect2Chars char="=" char1="&gt;" attribute="Operator" context="#stay"/>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -7,6 +7,7 @@ revisionHistory:
     - Add intrinsic modules to syntax highlighting
     - Add connect, invalidate to syntax highlighting
     - Add alternative `regreset` syntax
+    - Add literal identifiers to allow for legal numeric fields
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 2.2.0

--- a/spec.md
+++ b/spec.md
@@ -3403,13 +3403,16 @@ FIRRTL allows for two types of identifiers:
 Identifiers may only have the following characters: upper and lower case
 letters, digits, and `_`{.firrtl}. Identifiers cannot begin with a digit.
 
-Literal identifiers allow for using a string as an identifier which is not a
-legal identifier.  Such an identifier is encoded using leading and trailing
-backticks, `\``{.firrtl}.  E.g., it is legal to use `\`0\``{.firrtl} as a
-literal identifier in a Bundle field (or anywhere else an identifier may be
-used).  A FIRRTL compiler is allowed to change a literal identifier to an
-identifier of the target language (e.g., Verilog) if the literal identifier is
-not representable in the target language.
+Literal identifiers allow for using an expanded set of characters in an
+identifier.  Such an identifier is encoded using leading and trailing backticks,
+`\``{.firrtl}.  A literal identifier has the same restrictions as an identifier,
+_but it is allowed to start with a digit_.  E.g., it is legal to use
+`\`0\``{.firrtl} as a literal identifier in a Bundle field (or anywhere else an
+identifier may be used).
+
+A FIRRTL compiler is allowed to change a literal identifier to a legal
+identifier in the target language (e.g., Verilog) if the literal identifier is
+not directly representable in the target language.
 
 Comments begin with a semicolon and extend until the end of the line.  Commas
 are treated as whitespace, and may be used by the user for clarity if desired.
@@ -3625,7 +3628,8 @@ letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
        | "h" | "i" | "j" | "k" | "l" | "m" | "n"
        | "o" | "p" | "q" | "r" | "s" | "t" | "u"
        | "v" | "w" | "x" | "y" | "z" ;
-literal_id = "`" , string "`" ;
+literal_id =
+  "`" , ( "_" | letter | digit_dec ), { "_" | letter | digit_dec } , "`" ;
 id = ( "_" | letter ) , { "_" | letter | digit_dec } | literal_id ;
 
 (* Fileinfo communicates Chisel source file and line/column info *)

--- a/spec.md
+++ b/spec.md
@@ -3405,10 +3405,10 @@ letters, digits, and `_`{.firrtl}. Identifiers cannot begin with a digit.
 
 Literal identifiers allow for using an expanded set of characters in an
 identifier.  Such an identifier is encoded using leading and trailing backticks,
-`\``{.firrtl}.  A literal identifier has the same restrictions as an identifier,
-_but it is allowed to start with a digit_.  E.g., it is legal to use
-`\`0\``{.firrtl} as a literal identifier in a Bundle field (or anywhere else an
-identifier may be used).
+`` ` ``{.firrtl}.  A literal identifier has the same restrictions as an
+identifier, _but it is allowed to start with a digit_.  E.g., it is legal to use
+`` `0` ``{.firrtl} as a literal identifier in a Bundle field (or anywhere else
+an identifier may be used).
 
 A FIRRTL compiler is allowed to change a literal identifier to a legal
 identifier in the target language (e.g., Verilog) if the literal identifier is

--- a/spec.md
+++ b/spec.md
@@ -3640,7 +3640,7 @@ type_ground = "Clock" | "Reset" | "AsyncReset"
 type_aggregate = "{" , field , { field } , "}"
                | type , "[" , int_any , "]" ;
 type_ref = ( "Probe" | "RWProbe" ) , "<", type , ">" ;
-field = [ "flip" ] , ( id | string_sq ) , ":" , type ;
+field = [ "flip" ] , id , ":" , type ;
 type = ( [ "const" ] , ( type_ground | type_aggregate ) ) | type_ref ;
 
 (* Primitive operations *)
@@ -3675,7 +3675,7 @@ expr =
   | "read" , "(" , ref_expr , ")"
   | primop ;
 static_reference = id
-                 | static_reference , "." , ( id | string_sq )
+                 | static_reference , "." , id
                  | static_reference , "[" , int_any , "]" ;
 reference = static_reference
           | reference , "[" , expr , "]" ;

--- a/spec.md
+++ b/spec.md
@@ -584,8 +584,8 @@ UInt<16>[10][20]
 ### Bundle Types
 
 A bundle type is used to express a collection of nested and named types.  All
-fields in a bundle type must have a given name, and type.  All names must either
-be legal identifiers or quoted strings.
+fields in a bundle type must have a given name, and type.  All names must be
+legal identifiers.
 
 The following is an example of a possible type for representing a complex
 number. It has two fields, `real`{.firrtl}, and `imag`{.firrtl}, both 10-bit
@@ -2490,15 +2490,14 @@ module MyModule :
   out.a <= in ; out.a is of type const UInt
 ```
 
-A sub-field referring to a field whose name is a quoted string must also be a
-quoted string.  E.g., the following is a legal sub-field referring to the field
-`'0'`{.firrtl}:
+A sub-field referring to a field whose name is a literal identifier is shown
+below:
 
 ``` firrtl
 module MyModule :
-  input a: { '0' : { '0' : { b : UInt<1> } } }
+  input a: { `0` : { `0` : { b : UInt<1> } } }
   output b: UInt<1>
-  b <= a.'0'.'0'.b
+  b <= a.`0`.`0`.b
 ```
 
 ## Sub-indices
@@ -3396,8 +3395,21 @@ contain indeterminate values, do not need to be equal under comparison.
 FIRRTL's syntax is designed to be human-readable but easily algorithmically
 parsed.
 
-The following characters are allowed in identifiers: upper and lower case
+FIRRTL allows for two types of identifiers:
+
+1. Identifiers
+2. Literal Identifiers
+
+Identifiers may only have the following characters: upper and lower case
 letters, digits, and `_`{.firrtl}. Identifiers cannot begin with a digit.
+
+Literal identifiers allow for using a string as an identifier which is not a
+legal identifier.  Such an identifier is encoded using leading and trailing
+backticks, `\``{.firrtl}.  E.g., it is legal to use `\`0\``{.firrtl} as a
+literal identifier in a Bundle field (or anywhere else an identifier may be
+used).  A FIRRTL compiler is allowed to change a literal identifier to an
+identifier of the target language (e.g., Verilog) if the literal identifier is
+not representable in the target language.
 
 Comments begin with a semicolon and extend until the end of the line.  Commas
 are treated as whitespace, and may be used by the user for clarity if desired.
@@ -3613,7 +3625,8 @@ letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
        | "h" | "i" | "j" | "k" | "l" | "m" | "n"
        | "o" | "p" | "q" | "r" | "s" | "t" | "u"
        | "v" | "w" | "x" | "y" | "z" ;
-id = ( "_" | letter ) , { "_" | letter | digit_dec } ;
+literal_id = "`" , string "`" ;
+id = ( "_" | letter ) , { "_" | letter | digit_dec } | literal_id ;
 
 (* Fileinfo communicates Chisel source file and line/column info *)
 linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;

--- a/spec.md
+++ b/spec.md
@@ -584,8 +584,8 @@ UInt<16>[10][20]
 ### Bundle Types
 
 A bundle type is used to express a collection of nested and named types.  All
-fields in a bundle type must have a given name, and type.  All names must be
-legal identifiers.
+fields in a bundle type must have a given name, and type.  All names must either
+be legal identifiers or quoted strings.
 
 The following is an example of a possible type for representing a complex
 number. It has two fields, `real`{.firrtl}, and `imag`{.firrtl}, both 10-bit
@@ -2490,6 +2490,16 @@ module MyModule :
   out.a <= in ; out.a is of type const UInt
 ```
 
+A sub-field referring to a field whose name is a quoted string must also be a
+quoted string.  E.g., the following is a legal sub-field referring to the field
+`'0'`{.firrtl}:
+
+``` firrtl
+module MyModule :
+  input a: { '0' : { '0' : { b : UInt<1> } } }
+  output b: UInt<1>
+  b <= a.'0'.'0'.b
+```
 
 ## Sub-indices
 
@@ -3617,7 +3627,7 @@ type_ground = "Clock" | "Reset" | "AsyncReset"
 type_aggregate = "{" , field , { field } , "}"
                | type , "[" , int_any , "]" ;
 type_ref = ( "Probe" | "RWProbe" ) , "<", type , ">" ;
-field = [ "flip" ] , id , ":" , type ;
+field = [ "flip" ] , ( id | string_sq ) , ":" , type ;
 type = ( [ "const" ] , ( type_ground | type_aggregate ) ) | type_ref ;
 
 (* Primitive operations *)
@@ -3652,7 +3662,7 @@ expr =
   | "read" , "(" , ref_expr , ")"
   | primop ;
 static_reference = id
-                 | static_reference , "." , id
+                 | static_reference , "." , ( id | string_sq )
                  | static_reference , "[" , int_any , "]" ;
 reference = static_reference
           | reference , "[" , expr , "]" ;


### PR DESCRIPTION
Add literal identifiers which are identifiers that are escaped with
backticks.  This is used to encode an identifier which (extremely
narrowly) is an identifier but starts with a leading number.  This enables
extremely simple lexing and avoids any confusion with other possible
number types, e.g., floats or versions.

Add language that describes how this works for subfields.  E.g., to
subfield into an aggregate "foo" with field "`0`" you would do "foo.`0`".

---

Implements the @darthscsi suggestion from https://github.com/chipsalliance/firrtl-spec/pull/101#issuecomment-1529312052 with suggestions from @jackkoenig to use backticks.

The main use of this is to allow for numeric identifiers to not require context-sensitive lexing. E.g., `foo.0.0.bar` requires context passed from the parser to the lexer so that lexer doesn't see `0.0` and make it a float.

Note: the language in this patch is looser than needed. It allows any quoted string including:

```
circuit Foo:
  module Foo:
    input a: {`🎄`: UInt<1>}
    output b: {`🎄`: UInt<1>}

    connect b.`🎄`, a.`🎄`
```

Further note: the SFC has always accepted any string, e.g., `a: {🎄: UInt<1>}` is fine by the SFC. The MFC has never accepted this.