### PR TITLE
[Minor?] Start documenting and defining the ABI for FIRRTL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMG_EPSS=$(IMG_SRCS:include/img_src/%.dot=build/img/%.eps)
 .PHONY: all clean images
 .PRECIOUS: build/ build/img/
 
-all: build/spec.pdf
+all: build/spec.pdf build/abi.pdf
 
 clean:
 	rm -rf build
@@ -23,6 +23,9 @@ PANDOC_FLAGS=\
 	--metadata version:$(VERSION)
 
 build/spec.pdf: spec.md revision-history.yaml include/spec-template.tex include/firrtl.xml include/ebnf.xml $(IMG_EPSS) | build/
+	pandoc $< --metadata-file=revision-history.yaml $(PANDOC_FLAGS) -o $@
+
+build/abi.pdf: abi.md revision-history.yaml include/spec-template.tex include/firrtl.xml $(IMG_EPSS) | build/
 	pandoc $< --metadata-file=revision-history.yaml $(PANDOC_FLAGS) -o $@
 
 build/img/%.eps: include/img_src/%.dot | build/img/

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -8,6 +8,7 @@ revisionHistory:
     - Delineate string and single-quoted/double-quoted string in grammar.
     - Deprecate reference-first statements.
     - Tweak grammar of 'read' to support 'read(probe(x))' as in examples.
+    - Initial ABI description.
 
   # Information about the old versions.  This should be static.
   oldVersions:

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -6,6 +6,8 @@ revisionHistory:
   thisVersion:
     - Fix typos in force/release examples, force takes expr not int literal.
     - Delineate string and single-quoted/double-quoted string in grammar.
+    - Deprecate reference-first statements.
+  
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 2.0.1

--- a/spec.md
+++ b/spec.md
@@ -1070,6 +1070,18 @@ connected to the left-hand side field.  Conversely, if the i'th field is
 flipped, then the left-hand side field is connected to the right-hand side
 field.
 
+### Alternate Syntax
+
+Connects may also be specified by keyword.  This form is identical to the `<=` 
+form in operand order
+
+``` firrtl
+module MyModule :
+  input myinput: UInt
+  output myoutput: UInt
+  connect myoutput, myinput
+```
+
 ## Statement Groups
 
 An ordered sequence of one or more statements can be grouped into a single
@@ -1293,6 +1305,20 @@ sub-element in the bundle.
 
 Components of reference and analog type are ignored, as are any reference or
 analog types within the component (as they cannot be connected to).
+
+### Alternate Syntax
+
+Is invalid may also be specified by keyword.
+
+``` firrtl
+module MyModule :
+  input in: {flip a: UInt, b: UInt}
+  output out: {flip a: UInt, b: UInt}
+  wire w: {flip a: UInt, b: UInt}
+  invalidated in
+  invalidated out
+  invalidated w
+```
 
 ## Attaches
 
@@ -3607,7 +3633,9 @@ statement = "wire" , id , ":" , type , [ info ]
             { expr } , ")" , [ ":" , id ] , [ info ]
           | "skip" , [ info ]
           | "define" , static_reference , "=" , ref_expr , [ info ]
-          | force_release , [ info ] ;
+          | "force_release" , [ info ] ;
+          | "connect" , reference , "," , expr , [ info ]
+          | "invalidated" , reference , [ info ]
 
 (* Module definitions *)
 port = ( "input" | "output" ) , id , ":": , type , [ info ] ;
@@ -3644,6 +3672,10 @@ circuit =
   dedent ;
 ```
 
+## Deprecated Syntax
+
+`reference is invalid` and `reference <= expr` are deprecated and will be 
+replaced with the alternate syntax in a future revision.
 
 # Versioning Scheme of this Document
 

--- a/spec.md
+++ b/spec.md
@@ -1316,11 +1316,11 @@ module MyModule :
   input in: {flip a: UInt, b: UInt}
   output out: {flip a: UInt, b: UInt}
   wire w: {flip a: UInt, b: UInt}
-  invalidated in
+  invalidate in
   ; equivalent to "in is invalid"
-  invalidated out
+  invalidate out
   ; equivalent to "out is invalid"
-  invalidated w
+  invalidate w
   ; equivalent to "w is invalid"
 ```
 
@@ -3639,7 +3639,7 @@ statement = "wire" , id , ":" , type , [ info ]
           | "define" , static_reference , "=" , ref_expr , [ info ]
           | "force_release" , [ info ] ;
           | "connect" , reference , "," , expr , [ info ]
-          | "invalidated" , reference , [ info ]
+          | "invalidate" , reference , [ info ]
 
 (* Module definitions *)
 port = ( "input" | "output" ) , id , ":": , type , [ info ] ;

--- a/spec.md
+++ b/spec.md
@@ -3707,30 +3707,6 @@ force_release =
   | "release" , "(" , expr , "," , expr , "," , ref_expr , ")" ;
 
 (* Statements *)
-<<<<<<< HEAD
-statement = "wire" , id , ":" , type , [ info ]
-          | "reg" , id , ":" , type , expr ,
-            [ "with" , ":" , "(" , "reset" , "=>" ,
-              "(" , expr , "," , expr , ")", ")" ] ,
-            [ info ]
-          | memory
-          | "inst" , id , "of" , id , [ info ]
-          | "node" , id , "=" , expr , [ info ]
-          | reference , "<=" , expr , [ info ]
-          | reference , "is invalid" , [ info ]
-          | "attach(" , { reference } , ")" , [ info ]
-          | "when" , expr , ":" [ info ] , newline , indent ,
-              { statement } ,
-            dedent , [ "else" , ":" , indent , { statement } , dedent ]
-          | "stop(" , expr , "," , expr , "," , int_any , ")" , [ info ]
-          | "printf(" , expr , "," , expr , "," , string_dq ,
-            { expr } , ")" , [ ":" , id ] , [ info ]
-          | "skip" , [ info ]
-          | "define" , static_reference , "=" , ref_expr , [ info ]
-          | "force_release" , [ info ] ;
-          | "connect" , reference , "," , expr , [ info ]
-          | "invalidate" , reference , [ info ]
-=======
 statement =
     "wire" , id , ":" , type , [ info ]
   | "reg" , id , ":" , type , expr ,
@@ -3756,7 +3732,6 @@ statement =
   | force_release , [ info ]
   | "connect" , reference , "," , expr , [ info ]
   | "invalidate" , reference , [ info ]
->>>>>>> origin/main
 
 (* Module definitions *)
 port = ( "input" | "output" ) , id , ":" , type , [ info ] ;
@@ -3795,11 +3770,7 @@ circuit =
 
 ## Deprecated Syntax
 
-<<<<<<< HEAD
-`reference is invalid` and `reference <= expr` are deprecated and will be 
-=======
 `reference is invalid` and `reference <= expr` are deprecated and will be
->>>>>>> origin/main
 replaced with the alternate syntax in the next major revision.
 
 # Versioning Scheme of this Document

--- a/spec.md
+++ b/spec.md
@@ -1080,6 +1080,7 @@ module MyModule :
   input myinput: UInt
   output myoutput: UInt
   connect myoutput, myinput
+  ; equivalent to "myoutput <= myinput"
 ```
 
 ## Statement Groups
@@ -1308,7 +1309,7 @@ analog types within the component (as they cannot be connected to).
 
 ### Alternate Syntax
 
-Is invalid may also be specified by keyword.
+`is invalid`.{.firrtl} may also be specified by keyword.
 
 ``` firrtl
 module MyModule :
@@ -1316,8 +1317,11 @@ module MyModule :
   output out: {flip a: UInt, b: UInt}
   wire w: {flip a: UInt, b: UInt}
   invalidated in
+  ; equivalent to "in is invalid"
   invalidated out
+  ; equivalent to "out is invalid"
   invalidated w
+  ; equivalent to "w is invalid"
 ```
 
 ## Attaches
@@ -3675,7 +3679,7 @@ circuit =
 ## Deprecated Syntax
 
 `reference is invalid` and `reference <= expr` are deprecated and will be 
-replaced with the alternate syntax in a future revision.
+replaced with the alternate syntax in the next major revision.
 
 # Versioning Scheme of this Document
 


### PR DESCRIPTION
Start documenting the ABI for firrtl.  This is put in a new file as the semantics of FIRRTL are specified in the spec, whereas the mapping to verilog makes additional requirements which are independent of what is needed to ensure semantic preserving translation.