### PR TITLE
[minor] Add remote instantiation

### DIFF
--- a/abi.md
+++ b/abi.md
@@ -110,6 +110,51 @@ Passive bundles shall be lowered to Verilog packed structs.
 Reference types in ports shall be logically split out from aggregates and named
 as though "Aggregate Type Lowering" was used.
 
+### Remotely Instantiated Modules
+
+Remotely instantiated modules are lowered using the SystemVerilog
+`bind`{.verilog} statement.  All bind statements are placed in a separate file
+named `bindings_<circuit name>.sv`.
+
+For example, consider the following circuit `Foo`{.firrtl}` with remotely
+instantiated module `Bar`{.firrtl}:
+
+``` firrtl
+circuit Foo :
+  module Bar :
+    input a: UInt<1>
+
+  module Foo :
+    input b: UInt<1>
+
+    remote_inst bar of Bar
+    remote_inst.a <= b
+```
+
+This will produce the following two SystemVerilog modules:
+
+``` verilog
+module Foo(
+  input b
+);
+endmodule
+
+module Bar(
+  input a
+);
+endmodule
+```
+
+Additionally a `bindings_Foo.sv` file will be produced with the following
+contents:
+
+``` verilog
+bind Foo bar bar(.a(b));
+```
+
+Future changes to this ABI document will enable more fine-grained control of
+remote instantiation.
+
 ## On Types
 
 Types are only guaranteed to follow this lowering when the Verilog type is on an

--- a/abi.md
+++ b/abi.md
@@ -149,7 +149,7 @@ Additionally a `bindings_Foo.sv` file will be produced with the following
 contents:
 
 ``` verilog
-bind Foo bar bar(.a(b));
+bind Foo Bar bar(.a(b));
 ```
 
 Future changes to this ABI document will enable more fine-grained control of

--- a/abi.md
+++ b/abi.md
@@ -127,8 +127,8 @@ circuit Foo :
   module Foo :
     input b: UInt<1>
 
-    remote_inst bar of Bar
-    remote_inst.a <= b
+    remoteinst bar of Bar
+    bar.a <= b
 ```
 
 This will produce the following two SystemVerilog modules:

--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -16,7 +16,7 @@
       <item>is</item>
       <item>invalid</item>
       <item>inst</item>
-      <item>remote_inst</item>
+      <item>remoteinst</item>
       <item>of</item>
       <item>wire</item>
       <item>node</item>

--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -16,6 +16,7 @@
       <item>is</item>
       <item>invalid</item>
       <item>inst</item>
+      <item>remote_inst</item>
       <item>of</item>
       <item>wire</item>
       <item>node</item>

--- a/spec.md
+++ b/spec.md
@@ -1856,7 +1856,7 @@ module.  (See the FIRRTL ABI for more information on this lowering.)
 Remotely instantiated modules must only contain input ports of passive types or
 probe types.
 
-Remote instantiation uses the `remote_inst`{.firrtl} syntax as shown below:
+Remote instantiation uses the `remoteinst`{.firrtl} syntax as shown below:
 
 ``` firrtl
 circuit Foo :
@@ -1866,8 +1866,8 @@ circuit Foo :
   module Foo :
     input b: UInt<1>
 
-    remote_inst bar of Bar
-    remote_inst.a <= b
+    remoteinst bar of Bar
+    bar.a <= b
 ```
 
 Remotely instantiated modules are intended to be used to keep verification,

--- a/spec.md
+++ b/spec.md
@@ -1847,6 +1847,33 @@ To disallow infinitely recursive hardware, modules cannot contain instances of
 itself, either directly, or indirectly through instances of other modules it
 instantiates.
 
+## Remote Instances
+
+FIRRTL modules may also be remotely instantiated.  A remotely instantiated
+module will cause the instantiation to be emitted outside its instantiating
+module.  (See the FIRRTL ABI for more information on this lowering.)
+
+Remotely instantiated modules must only contain input ports of passive types or
+probe types.
+
+Remote instantiation uses the `remote_inst`{.firrtl} syntax as shown below:
+
+``` firrtl
+circuit Foo :
+  module Bar :
+    input a: UInt<1>
+
+  module Foo :
+    input b: UInt<1>
+
+    remote_inst bar of Bar
+    remote_inst.a <= b
+```
+
+Remotely instantiated modules are intended to be used to keep verification,
+debugging, or informational FIRRTL statements, not relevant to the operation of
+the main circuit, in a separate area.
+
 ## Stops
 
 The stop statement is used to halt simulations of the circuit. Backends are free
@@ -3679,7 +3706,7 @@ statement =
   | "regreset" , id , ":" , type , "," , expr , "," , expr , "," , expr ,
     [info]
   | memory
-  | "inst" , id , "of" , id , [ info ]
+  | ( "inst" | "remote_inst" ) , id , "of" , id , [ info ]
   | "node" , id , "=" , expr , [ info ]
   | reference , "<=" , expr , [ info ]
   | reference , "is invalid" , [ info ]


### PR DESCRIPTION
Add remote instantiation with the "remote_inst foo of Foo" syntax.  This is a FIRRTL-native representation of an instantiation that should be lowered to a SystemVerilog bind.