### PR TITLE
[minor] Add groups

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -6,6 +6,7 @@
       <item>module</item>
       <item>extmodule</item>
       <item>intmodule</item>
+      <item>declgroup</item>
     </list>
     <list name="keywords">
       <item>input</item>
@@ -14,6 +15,7 @@
       <item>parameter</item>
       <item>skip</item>
       <item>inst</item>
+      <item>group</item>
       <item>of</item>
       <item>wire</item>
       <item>node</item>
@@ -148,7 +150,7 @@
       <context name="info" attribute="Info" lineEndContext="#stay">
         <DetectChar char="]" context="#pop"/>
       </context>
-      <context name="outertype" attribute="Keyword" lineEndContext="#pop">
+      <context name="outertype" attribute="ID" lineEndContext="#pop">
         <DetectChar char="&lt;" attribute="Operator" context="#stay"/>
         <keyword String="types" attribute="Keyword" context="type"/>
         <Detect2Chars char="{" char1="|" context="field" attribute="Separator"/>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -4,6 +4,10 @@ revisionHistory:
   # populated using the "version" that the Makefile grabs from git.  Notable
   # additions to the specification should append entries here.
   thisVersion:
+    spec:
+      - Add optional groups.
+    abi:
+      - Add ABI for optional groups.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 3.1.0


### PR DESCRIPTION
Alternative to adding remote instantiation.  This introduces a "group" concept which is a way of putting a bunch of statements in a box which are destined to live in a bind.

This introduces a "defgroup" which enables a circuit or external module (which are two things which should be fungible) to declare that it has groups.  Because SystemVerilog bind disallows bind-under-bind, we need some way of guaranteeing that a specific extmodule/circuit is not later bound.

There is a middle-ground solution which would add remote instantiation indicating a group (h/t @mwachs5) and `defgroup`.  This would likely simplify some of the complexity by adding `group`.  However, the same rules of a `group` should likely apply to a remote instance, e.g., a remote instance/group cannot drive anything in the circuit except possibly via force.