### PR TITLE
[major] Disallow self-referential registers

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1207,6 +1207,20 @@ reg myreg: SInt, myclock with: (reset => (myreset, myinit))
 A register is initialized with an indeterminate value (see
 [@sec:indeterminate-values]).
 
+A register may not be declared with references to itself.  Any circuit that
+requires this must use a wire as a temporary.  E.g., the following shows an
+illegal register that references itself and an equivalent version that avoids
+the self reference:
+
+``` firrtl
+reg r: UInt<1>, asClock(r)
+
+; The above can be rewritten to:
+wire tmp: UInt<1>
+reg s: UInt<1>, asClock(tmp)
+tmp <= s
+```
+
 ### Alternative Syntax
 
 A register with a reset may also be declared using an alternative syntax using


### PR DESCRIPTION
Remove a tedious parsing issue stemming from Chisel emitting reset-less registers with a reference to themselves.  This construction is shown below:

    reg r: UInt<1>, clock with (reset => (UInt<1>(0), r))

This construction requires special parsing unless the identifier "r" is entered into the namespace immediately upon parsing.  It is easier to just disallow this and require FIRRTL-targeting languages to either emit reset-less registers or use wires for situations where they have true self-referential behavior.

Note: I'm changing Chisel to stop emitting this here: https://github.com/chipsalliance/chisel/pull/3280

Further note: The above construction is currently special-cased in CIRCT, but somebody could hand-write FIRRTL with weird expressions that include the register in any of the clock, reset signal, or reset value which are easier to just avoid.