### PR TITLE
[minor] add enumeration types and match statements

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -111,8 +111,8 @@
         <keyword attribute="Conditional" context="#stay" String="conditionals" />
         <Detect2Chars char="(" char1="*" attribute="Info" context="info"/>
         <DetectChar char= ";" context="comment" attribute="Comment"/>
+        <Detect2Chars char="{" char1="|" context="field" attribute="Separator"/>
         <DetectChar char="{" context="field" attribute="Separator"/>
-        <Detect2Chars char="{" char1="|" context="enumField" attribute="Separator"/>
         <Detect2Chars char="&lt;" char1="=" attribute="Operator" context="#stay"/>
         <Detect2Chars char="&lt;" char1="-" attribute="Operator" context="#stay"/>
         <Detect2Chars char="=" char1="&gt;" attribute="Operator" context="#stay"/>
@@ -158,10 +158,10 @@
       <context name="outertype" attribute="Keyword" lineEndContext="#pop">
         <DetectChar char="&lt;" attribute="Operator" context="#stay"/>
         <keyword String="types" attribute="Keyword" context="type"/>
+        <Detect2Chars char="{" char1="|" context="field" attribute="Separator"/>
+        <Detect2Chars char="|" char1="}" attribute="Separator" context="#pop#pop"/>
         <DetectChar char="{" context="field" attribute="Separator"/>
         <DetectChar char="}" attribute="Separator" context="#pop#pop"/>
-        <Detect2Char char="{" char1="|" context="enumField" attribute="Separator"/>
-        <Detect2Char char="}" char1="|" attribute="Separator" context="#pop#pop"/>
         <DetectChar char= ";" context="comment" attribute="Comment"/>
         <AnyChar String="&gt;," attribute="Operator" context="#pop"/>
         <DetectChar char="[" attribute="Operator" context="widthOrDepthOrLit"/>
@@ -170,6 +170,7 @@
         <AnyChar String="&lt;[(" attribute="Operator" context="widthOrDepthOrLit"/>
         <AnyChar String="," attribute="Separator" context="#pop"/>
         <AnyChar String="}" attribute="Separator" context="#pop#pop"/>
+        <Detect2Chars char="|" char1="}" attribute="Separator" context="#pop#pop"/>
         <DetectChar char= ";" context="comment" attribute="Comment"/>
         <AnyChar String="&gt;" attribute="Operator" context="#pop"/>
       </context>
@@ -182,17 +183,10 @@
         <keyword String="types" attribute="Keyword" context="type"/>
         <keyword String="outertype" attribute="Keyword" context="outertype"/>
         <keyword String="typemodifiers" attribute="Keyword" context="#stay"/>
+        <Detect2Chars char="{" char1="|" attribute="Separator" context="field"/>
+        <Detect2Chars char="|" char1="}" attribute="Separator" context="#pop"/>
         <DetectChar char="{" attribute="Separator" context="field"/>
         <DetectChar char="}" attribute="Separator" context="#pop"/>
-        <AnyChar String=":," attribute="Separator" context="#stay"/>
-        <DetectChar char= ";" context="comment" attribute="Comment"/>
-      </context>
-      <context name="enumField" attribute="ID" lineEndContext="#stay">
-        <keyword String="types" attribute="Keyword" context="type"/>
-        <keyword String="outertype" attribute="Keyword" context="outertype"/>
-        <keyword String="typemodifiers" attribute="Keyword" context="#stay"/>
-        <Detect2Char char="{" char1="|" attribute="Separator" context="field"/>
-        <Detect2Char char="}" char1="|" attribute="Separator" context="#pop"/>
         <AnyChar String=":," attribute="Separator" context="#stay"/>
         <DetectChar char= ";" context="comment" attribute="Comment"/>
       </context>

--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -44,6 +44,7 @@
     <list name="conditionals">
       <item>when</item>
       <item>else</item>
+      <item>match</item>
     </list>
     <list name="primops">
       <item>attach</item>
@@ -111,6 +112,7 @@
         <Detect2Chars char="(" char1="*" attribute="Info" context="info"/>
         <DetectChar char= ";" context="comment" attribute="Comment"/>
         <DetectChar char="{" context="field" attribute="Separator"/>
+        <Detect2Chars char="{" char1="|" context="enumField" attribute="Separator"/>
         <Detect2Chars char="&lt;" char1="=" attribute="Operator" context="#stay"/>
         <Detect2Chars char="&lt;" char1="-" attribute="Operator" context="#stay"/>
         <Detect2Chars char="=" char1="&gt;" attribute="Operator" context="#stay"/>
@@ -158,6 +160,8 @@
         <keyword String="types" attribute="Keyword" context="type"/>
         <DetectChar char="{" context="field" attribute="Separator"/>
         <DetectChar char="}" attribute="Separator" context="#pop#pop"/>
+        <Detect2Char char="{" char1="|" context="enumField" attribute="Separator"/>
+        <Detect2Char char="}" char1="|" attribute="Separator" context="#pop#pop"/>
         <DetectChar char= ";" context="comment" attribute="Comment"/>
         <AnyChar String="&gt;," attribute="Operator" context="#pop"/>
         <DetectChar char="[" attribute="Operator" context="widthOrDepthOrLit"/>
@@ -180,6 +184,15 @@
         <keyword String="typemodifiers" attribute="Keyword" context="#stay"/>
         <DetectChar char="{" attribute="Separator" context="field"/>
         <DetectChar char="}" attribute="Separator" context="#pop"/>
+        <AnyChar String=":," attribute="Separator" context="#stay"/>
+        <DetectChar char= ";" context="comment" attribute="Comment"/>
+      </context>
+      <context name="enumField" attribute="ID" lineEndContext="#stay">
+        <keyword String="types" attribute="Keyword" context="type"/>
+        <keyword String="outertype" attribute="Keyword" context="outertype"/>
+        <keyword String="typemodifiers" attribute="Keyword" context="#stay"/>
+        <Detect2Char char="{" char1="|" attribute="Separator" context="field"/>
+        <Detect2Char char="}" char1="|" attribute="Separator" context="#pop"/>
         <AnyChar String=":," attribute="Separator" context="#stay"/>
         <DetectChar char= ";" context="comment" attribute="Comment"/>
       </context>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -7,6 +7,7 @@ revisionHistory:
     - Add intrinsic modules to syntax highlighting
     - Add connect, invalidate to syntax highlighting
     - Add alternative `regreset` syntax
+    - Add enumeration types, match statements, and enumeration expressions
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 2.2.0

--- a/spec.md
+++ b/spec.md
@@ -1361,6 +1361,9 @@ node mynode = mux(pred, a, b)
 
 ## Conditionals
 
+Several statements provide branching in the data-flow and conditional control
+of verification constructs.
+
 ### When Statements
 
 Connections within a when statement that connect to previously declared

--- a/spec.md
+++ b/spec.md
@@ -2467,26 +2467,6 @@ the data type is `UInt<0>(0)`, where it is implicitly defined to be
 {|some: UInt<8>, None|}(Some, x)
 ```
 
-## Vector Expressions
-
-A vector can be constructed by specifying a list of values and a return type
-specifier.
-
-``` firrtl
-[UInt(2), UInt(3), UInt(4)] : UInt<8>[3]
-[io.a, io.b, io.c] : UInt<32>[3]
-```
-
-## Bundle Expressions
-
-A bundle can be constructed by specifying the field values using a bundle-like
-syntax, and a return type specifier.
-
-``` firrtl
-{a: UInt(0)} : {a : UInt<8>}
-{enable: io.in} : {enable : UInt<1>}
-```
-
 ## References
 
 A reference is simply a name that refers to a previously declared circuit

--- a/spec.md
+++ b/spec.md
@@ -549,32 +549,10 @@ Analog<32> ; 32-bit analog type
 Analog     ; analog type with inferred width
 ```
 
-### Enumeration Types
-
-Enumerations are structural disjoint union types.  An enumeration has a number
-of variants, each with a type.  The different variants are specified with tags.
-The variant types of an enumeration must all be passive and cannot contain
-analog or probe types.
-
-In the following example, the first variant has the tag `a` with type `UInt<8>`,
-and the second variant has the tag `b` with type `UInt<16>`.
-
-``` firrtl
-{|a: UInt<8>, b: UInt<16>|}
-```
-
-A variant may optionally omit the type, in which case it is implicitly defined
-to be `UInt<0>`. In the following example, all variants have the type
-`UInt<0>`.
-
-``` firrtl
-{|a, b, c|}
-```
-
 ## Aggregate Types
 
-FIRRTL supports two aggregate types: vectors and bundles.  Aggregate types are
-composed of ground types or other aggregate types.
+FIRRTL supports three aggregate types: vectors, bundles, and enumeration.
+Aggregate types are composed of ground types or other aggregate types.
 
 ### Vector Types
 
@@ -662,6 +640,28 @@ the module.  The `c`{.firrtl} sub-field contained in the `b`{.firrtl} sub-field
 flows into the module, and the `d`{.firrtl} sub-field contained in the
 `b`{.firrtl} sub-field flows out of the module.
 
+### Enumeration Types
+
+Enumerations are structural disjoint union types.  An enumeration has a number
+of variants, each with a type.  The different variants are specified with tags.
+The variant types of an enumeration must all be passive and cannot contain
+analog or probe types.
+
+In the following example, the first variant has the tag `a`{.firrtl} with type
+`UInt<8>`{.firrtl}, and the second variant has the tag `b`{.firrtl} with type 
+`UInt<16>`{.firrtl}.
+
+``` firrtl
+{|a: UInt<8>, b: UInt<16>|}
+```
+
+A variant may optionally omit the type, in which case it is implicitly defined
+to be `UInt<0>`{.firrtl}. In the following example, all variants have the type
+`UInt<0>`{.firrtl}.
+
+``` firrtl
+{|a, b, c|}
+```
 
 ## Reference Types
 

--- a/spec.md
+++ b/spec.md
@@ -1534,9 +1534,9 @@ variant.
 
 ``` firrtl
 match x:
-  #Some(x):
-    a <= x
-  #None:
+  #some(v):
+    a <= v
+  #none:
     e <= f
 ```
 
@@ -2457,8 +2457,10 @@ SInt("h-2a")
 
 ## Enum Expressions
 
-An enumeration can be constructed by specifying the variant tag, an optional
-data value expression, and a return type specifier.
+An enumeration can be constructed by specifying the variant tag, a data value
+expression, and a return type specifier. The data value expression may be
+omitted when the data type is `UInt<0>(0)`, where it is implicitly defined to
+be `UInt<0>(0)`.
 
 ``` firrtl
 #a : [#a, #b, #c]

--- a/spec.md
+++ b/spec.md
@@ -3665,7 +3665,8 @@ type_aggregate = "{" , field , { field } , "}"
                | type , "[" , int_any , "]" ;
 type_ref = ( "Probe" | "RWProbe" ) , "<", type , ">" ;
 field = [ "flip" ] , id , ":" , type ;
-type = ( [ "const" ] , ( type_ground | type_aggregate ) ) | type_ref ;
+type = ( [ "const" ] , ( type_ground | type_enum | type_aggregate ) )
+     | type_ref ;
 
 (* Primitive operations *)
 primop_2expr_keyword =

--- a/spec.md
+++ b/spec.md
@@ -1031,8 +1031,8 @@ It cannot be connected to both a `UInt`{.firrtl} and an `AsyncReset`{.firrtl}.
 The `AsyncReset`{.firrtl} type can be connected to another
 `AsyncReset`{.firrtl} or to a `Reset`{.firrtl}.
 
-Two enumeration types' are equivalent if both have the same number of variants,
-and both the enumeration's i'th variants have matching names and equivalent
+Two enumeration types are equivalent if both have the same number of variants,
+and both the enumerations' i'th variants have matching names and equivalent
 types.
 
 Two vector types are equivalent if they have the same length, and if their
@@ -2469,8 +2469,8 @@ SInt("h-2a")
 
 An enumeration can be constructed by applying an enumeration type to a variant
 tag and a data value expression. The data value expression may be omitted when
-the data type is `UInt<0>(0)`, where it is implicitly defined to be
-`UInt<0>(0)`.
+the data type is `UInt<0>(0)`{.firrtl}, where it is implicitly defined to be
+`UInt<0>(0)`{.firrtl}.
 
 ``` firrtl
 {|a, b, c|}(a)
@@ -3558,18 +3558,6 @@ The lowering algorithm for the scalarized convention operates as follows:
    suffix, `_<name>`, to the field called `name`. Fields are scalarized
    recursively, depth-first, and left-to-right.
 
-5. Enumeration-typed ports are scalarized to a tag port and a value port. The
-   tag port is appended with the suffix `_tag` and is a `UInt` type with the
-   minimum number of bits needed to represent the tags of all members of the
-   enumeration type.  The data port is appended with the suffix `_data` and is
-   a `UInt` with the minimum number of bits needed to represent the largest
-   data of all members of the enumeration type. Each member of the enumeration
-   has its data mapped to the lowered data port starting at the most
-   significant byte and taking up as many bits as they are wide.  Aggregate
-   data is mapped recursively, depth-first, and left-to-right to contiguous
-   bits of the data port. Enumeration data maps the tag followed by the value
-   port.
-
 E.g., consider the following port:
 
 ``` firrtl
@@ -3682,13 +3670,13 @@ width = "<" , int_any , ">" ;
 type_ground = "Clock" | "Reset" | "AsyncReset"
             | ( "UInt" | "SInt" | "Analog" ) , [ width ] ;
 type_enum = "{|" , { field_enum } , "|}" ;
-field_enum = id, [ ":" , type ] ;
+field_enum = id, [ ":" , type_simple_child ] ;
 type_aggregate = "{" , field , { field } , "}"
                | type , "[" , int_any , "]" ;
 type_ref = ( "Probe" | "RWProbe" ) , "<", type , ">" ;
 field = [ "flip" ] , id , ":" , type ;
-type = ( [ "const" ] , ( type_ground | type_enum | type_aggregate ) )
-     | type_ref ;
+type_simple_child = type_ground | type_enum | type_aggregate ;
+type = ( [ "const" ] , type_simple_child ) | type_ref ;
 
 (* Primitive operations *)
 primop_2expr_keyword =

--- a/spec.md
+++ b/spec.md
@@ -3659,6 +3659,8 @@ info = "@" , "[" , lineinfo, { ",", lineinfo }, "]" ;
 width = "<" , int_any , ">" ;
 type_ground = "Clock" | "Reset" | "AsyncReset"
             | ( "UInt" | "SInt" | "Analog" ) , [ width ] ;
+type_enum = "{|" , { field_enum } , "|}" ;
+field_enum = id, [ ":" , type ] ;
 type_aggregate = "{" , field , { field } , "}"
                | type , "[" , int_any , "]" ;
 type_ref = ( "Probe" | "RWProbe" ) , "<", type , ">" ;
@@ -3692,6 +3694,7 @@ primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
 (* Expression definitions *)
 expr =
     ( "UInt" | "SInt" ) , [ width ] , "(" , int_any , ")"
+  | type_enum , "(" , id , [ expr ] , ")"
   | reference
   | "mux" , "(" , expr , "," , expr , "," , expr , ")"
   | "read" , "(" , ref_expr , ")"
@@ -3742,6 +3745,9 @@ statement =
   | "when" , expr , ":" [ info ] , newline ,
     indent , statement, { statement } , dedent ,
     [ "else" , ":" , indent , statement, { statement } , dedent ]
+  | "match" , expr , ":" , [ info ] , newline ,
+    [ indent , { id , [ "(" , id , ")" ] , ":" , newline , 
+    [ indent , { statement } , dedent ] } , dedent ]
   | "stop(" , expr , "," , expr , "," , int , ")" , [ info ]
   | "printf(" , expr , "," , expr , "," , string_dq ,
     { expr } , ")" , [ ":" , id ] , [ info ]

--- a/spec.md
+++ b/spec.md
@@ -549,6 +549,19 @@ Analog<32> ; 32-bit analog type
 Analog     ; analog type with inferred width
 ```
 
+### Enumeration Types
+
+Enumerations are structural disjoint union types.  An enumeration has a number
+of variants, each with a type.  The different variants are specified with tags.
+A variant may optionally omit the data type, in which case it is implicitly
+defined to be `UInt<0>`. The variant types of an enumeration must all be
+passive and cannot contain analog types.
+
+``` firrtl
+[#a, #b, #c]
+[#some: UInt<8>, #none]
+```
+
 ## Aggregate Types
 
 FIRRTL supports two aggregate types: vectors and bundles.  Aggregate types are
@@ -1009,6 +1022,9 @@ It cannot be connected to both a `UInt`{.firrtl} and an `AsyncReset`{.firrtl}.
 The `AsyncReset`{.firrtl} type can be connected to another
 `AsyncReset`{.firrtl} or to a `Reset`{.firrtl}.
 
+Two enumeration types are equivalent if both have the same number of variants,
+and both the enumeration's i'th variants have matching names and types.
+
 Two vector types are equivalent if they have the same length, and if their
 element types are equivalent.
 
@@ -1377,7 +1393,9 @@ node mynode = mux(pred, a, b)
 
 ## Conditionals
 
-Connections within a conditional statement that connect to previously declared
+### When Statements
+
+Connections within a when statement that connect to previously declared
 components hold only when the given condition is high. The condition must have a
 1-bit unsigned integer type.
 
@@ -1397,7 +1415,7 @@ module MyModule :
     x <= b
 ```
 
-### Syntactic Shorthands
+#### Syntactic Shorthands
 
 The `else`{.firrtl} branch of a conditional statement may be omitted, in which
 case a default `else`{.firrtl} branch is supplied consisting of the empty
@@ -1505,6 +1523,21 @@ The `else`{.firrtl} branch may also be added to the single line:
 
 ``` firrtl
 when c : a <= b else : e <= f
+```
+
+### Match Statements
+
+Match statements are used to discriminate the active variant of a enumeration
+typed expression.  A match statement must exhaustively test every variant of an
+enumeration. An optional binder may be specified to extract the data of the
+variant.
+
+``` firrtl
+match x:
+  #Some(x):
+    a <= x
+  #None:
+    e <= f
 ```
 
 ### Nested Declarations
@@ -2420,6 +2453,36 @@ SInt("b-101010")
 SInt("o-52")
 SInt("h-2A")
 SInt("h-2a")
+```
+
+## Enum Expressions
+
+An enumeration can be constructed by specifying the variant tag, an optional
+data value expression, and a return type specifier.
+
+``` firrtl
+#a : [#a, #b, #c]
+#some(UInt<8>(1)) : [#some: UInt<8>, #none]
+```
+
+## Vector Expressions
+
+A vector can be constructed by specifying a list of values and a return type
+specifier.
+
+``` firrtl
+[UInt(2), UInt(3), UInt(4)] : UInt<8>[3]
+[io.a, io.b, io.c] : UInt<32>[3]
+```
+
+## Bundle Expressions
+
+A bundle can be constructed by specifying the field values using a bundle-like
+syntax, and a return type specifier.
+
+``` firrtl
+{a: UInt(0)} : {a : UInt<8>}
+{enable: io.in} : {enable : UInt<1>}
 ```
 
 ## References

--- a/spec.md
+++ b/spec.md
@@ -558,8 +558,8 @@ defined to be `UInt<0>`. The variant types of an enumeration must all be
 passive and cannot contain analog types.
 
 ``` firrtl
-[#a, #b, #c]
-[#some: UInt<8>, #none]
+{|a, b, c|}
+{|some: UInt<8>, none|}
 ```
 
 ## Aggregate Types
@@ -1534,9 +1534,9 @@ variant.
 
 ``` firrtl
 match x:
-  #some(v):
+  some(v):
     a <= v
-  #none:
+  none:
     e <= f
 ```
 
@@ -2457,14 +2457,14 @@ SInt("h-2a")
 
 ## Enum Expressions
 
-An enumeration can be constructed by specifying the variant tag, a data value
-expression, and a return type specifier. The data value expression may be
-omitted when the data type is `UInt<0>(0)`, where it is implicitly defined to
-be `UInt<0>(0)`.
+An enumeration can be constructed by applying an enumeration type to a variant
+tag and a data value expression. The data value expression may be omitted when
+the data type is `UInt<0>(0)`, where it is implicitly defined to be
+`UInt<0>(0)`.
 
 ``` firrtl
-#a : [#a, #b, #c]
-#some(UInt<8>(1)) : [#some: UInt<8>, #none]
+{|a, b, c|}(a)
+{|some: UInt<8>, None|}(Some, x)
 ```
 
 ## Vector Expressions


### PR DESCRIPTION
Add product types to firrtl.  These are called enums after rust and swift.  Other languages might call them discriminated unions.  The type carries a discriminator which is a set of identifiers, each a tag corresponding to one variant.  The type also carries a union, with each variant of the union corresponding to a specific tag.  A value of enum type will have one tag and the data associated with that tag.  Match statements provide a way to decompose an enum.  Enum construction is provided in the same manner as ground types.

An enum with empty fields (just tags) is expected to map to a Verilog enum.  An enum with fields maps to a verilog tagged union in spirit, but due to almost no tools support synthesis of packed tagged unions (or even just packed tagged unions as a recognized type), there will be a more complex lowering which will be detailed in the ABI document.

Several things are intentionally left off at this point.  These include controlling the tags' integer values, extracting the tag as an integer, casting enums to/from integers unsafely, and match failures (tag outside declared set of values).

This PR is a cleanup of https://github.com/chipsalliance/firrtl-spec/pull/94 with the intent to merge.