### PR TITLE
[NFC] Update formatting on match grammar

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3726,8 +3726,11 @@ statement =
     indent , statement, { statement } , dedent ,
     [ "else" , ":" , indent , statement, { statement } , dedent ]
   | "match" , expr , ":" , [ info ] , newline ,
-    [ indent , { id , [ "(" , id , ")" ] , ":" , newline ,
-    [ indent , { statement } , dedent ] } , dedent ]
+    [ indent ,
+      { id , [ "(" , id , ")" ] , ":" , newline ,
+        [ indent , { statement } , dedent ]
+      } ,
+      dedent ]
   | "stop(" , expr , "," , expr , "," , int , ")" , [ info ]
   | "printf(" , expr , "," , expr , "," , string_dq ,
     { expr } , ")" , [ ":" , id ] , [ info ]


### PR DESCRIPTION
The prior formatting made it easy to miss the statement group was split with a newline.