### PR TITLE
[patch] Fixup printf grammar to reflect need for commas between exprs.

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -4,10 +4,11 @@ revisionHistory:
   # populated using the "version" that the Makefile grabs from git.  Notable
   # additions to the specification should append entries here.
   thisVersion:
-  # Information about the old versions.  This should be static.
     spec:
       - Change/clarify mux selector width inference to align with other operations
         (must infer to some width by itself, pad if infers to less than 1-bit).
+      - Fix printf grammar, expect commas between arguments.
+  # Information about the old versions.  This should be static.
   oldVersions:
     - version: 3.0.0
       spec:

--- a/spec.md
+++ b/spec.md
@@ -3735,7 +3735,7 @@ statement =
       dedent ]
   | "stop(" , expr , "," , expr , "," , int , ")" , [ info ]
   | "printf(" , expr , "," , expr , "," , string_dq ,
-    { expr } , ")" , [ ":" , id ] , [ info ]
+    { "," , expr } , ")" , [ ":" , id ] , [ info ]
   | "skip" , [ info ]
   | "define" , static_reference , "=" , ref_expr , [ info ]
   | force_release , [ info ]


### PR DESCRIPTION
While current implementations ignore commas when parsing, this is not what the grammar says and more to the point as-is the use of commas makes the proper printf syntax invalid.  Fix.