### PR TITLE
[patch] Tweak mux selector width-inference behavior.

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,6 +5,9 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
   # Information about the old versions.  This should be static.
+    spec:
+      - Change/clarify mux selector width inference to align with other operations
+        (must infer to some width by itself, pad if infers to less than 1-bit).
   oldVersions:
     - version: 3.0.0
       spec:

--- a/spec.md
+++ b/spec.md
@@ -2668,9 +2668,11 @@ A multiplexer expression is legal only if the following holds.
 
 1. The width of the selection signal is any of:
 
+    1. Zero-bit
+
     1. One-bit
 
-    1. Unspecified, but will infer to one-bit
+    1. Unspecified, but is illegal if infers to wider than one-bit
 
 1. The types of the two input expressions are equivalent.
 


### PR DESCRIPTION
Don't require inferring selector to 1-bit:
* Support inferring to zero-bit (will be padded)
* Don't put constraints on operands ("back-propagation").
* Align with behavior in similar constructs: when, subaccess.

As-is selector can be entirely unconstrained otherwise, but will inferred to one-bit when used in a mux.

This masks design bugs and has no known utility.

Further, by requiring inference to 1-bit this can cause hardware that otherwise would be zero-width (and often elided) to become 1-bit and kept around.

Instead treat the selector like any other operand, but still reject if selector is inferred to be larger than 1 bit.

See https://github.com/llvm/circt/issues/5444 for further discussion and examples demonstrating the issue on current and historical implementations.