### PR TITLE
Add Integer property type.

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -31,6 +31,7 @@
       <item>Clock</item>
       <item>Reset</item>
       <item>AsyncReset</item>
+      <item>Integer</item>
     </list>
     <list name="outertype">
       <item>Probe</item>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,6 +5,7 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
     spec:
+      - Add Integer property type.
       - Add initial description of property types.
     abi:
       - Add initial description of property types.

--- a/spec.md
+++ b/spec.md
@@ -953,6 +953,20 @@ existence of property types does not affect hardware functionality or the
 hardware ABI. For example, it is valid to drop property types from the IR
 completely.
 
+Property types are legal in the following constructs:
+
+* Port declarations on modules and external modules
+
+### Integer Property Types
+
+Integer properties represent arbitrary bit width signed integer values with a
+two's complement representation.
+
+``` firrtl
+module Example:
+  input intProp : Integer ; an input port of Integer property type
+```
+
 ## Type Modifiers
 
 ### Constant Type
@@ -3669,6 +3683,7 @@ type_aggregate = "{" , field , { field } , "}"
                | type , "[" , int , "]" ;
 type_ref = ( "Probe" | "RWProbe" ) , "<", type , ">" ;
 field = [ "flip" ] , id , ":" , type ;
+type_property = "Integer" ;
 type_simple_child = type_ground | type_enum | type_aggregate | id ;
 type = ( [ "const" ] , type_simple_child ) | type_ref ;
 
@@ -3764,7 +3779,7 @@ statement =
   | "invalidate" , reference , [ info ] ;
 
 (* Module definitions *)
-port = ( "input" | "output" ) , id , ":" , type , [ info ] ;
+port = ( "input" | "output" ) , id , ":" , (type | type_property) , [ info ] ;
 module = "module" , id , ":" , [ info ] , newline , indent ,
            { port , newline } ,
            { statement , newline } ,

--- a/spec.md
+++ b/spec.md
@@ -959,8 +959,7 @@ Property types are legal in the following constructs:
 
 ### Integer Property Types
 
-Integer properties represent arbitrary bit width signed integer values with a
-two's complement representation.
+Integer property types represent arbitrary precision signed integer values.
 
 ``` firrtl
 module Example:


### PR DESCRIPTION
This adds the first concrete property type: Integer. Integer
properties are arbitrary bit width integer values. This also indicates
where concrete property types are legal, and updates the grammar. For
now, the only legal location is in ports.