### PR TITLE
Fix "Type Alias" section location. 

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -6,6 +6,8 @@ revisionHistory:
   thisVersion:
     spec:
       - Add optional groups.
+      - Fix position of "Type Alias" (it used to be in the middle of
+        "Reference Types").
     abi:
       - Add ABI for optional groups.
   # Information about the old versions.  This should be static.
@@ -16,8 +18,9 @@ revisionHistory:
         - Add property assignment.
         - Add Integer property type.
         - Add initial description of property types.
-        - Change/clarify mux selector width inference to align with other operations
-          (must infer to some width by itself, pad if infers to less than 1-bit).
+        - Change/clarify mux selector width inference to align with other
+          operations (must infer to some width by itself, pad if infers to less
+          than 1-bit).
         - Fix printf grammar, expect commas between arguments.
         - Fix spec bug where string-encoded literals were still used in examples
           of "Constant Integer Expression".
@@ -87,8 +90,8 @@ revisionHistory:
       spec:
         - Specify behavior of zero bit width integers, add zero-width literals
         - Specify behavior of indeterminate values
-        - Add an explicit section about "Aggregate Types" and move "Vector Type" and
-          "Bundle Type" under it.
+        - Add an explicit section about "Aggregate Types" and move "Vector Type"
+          and "Bundle Type" under it.
         - Move "head" and "tail" from primop_1expr_keyword to
           primop_1expr1int_keyword in the "FIRRTL Language Definition".
         - Add in-line annotation format

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -18,9 +18,8 @@ revisionHistory:
         - Add property assignment.
         - Add Integer property type.
         - Add initial description of property types.
-        - Change/clarify mux selector width inference to align with other
-          operations (must infer to some width by itself, pad if infers to less
-          than 1-bit).
+        - Change/clarify mux selector width inference to align with other operations
+          (must infer to some width by itself, pad if infers to less than 1-bit).
         - Fix printf grammar, expect commas between arguments.
         - Fix spec bug where string-encoded literals were still used in examples
           of "Constant Integer Expression".
@@ -90,8 +89,8 @@ revisionHistory:
       spec:
         - Specify behavior of zero bit width integers, add zero-width literals
         - Specify behavior of indeterminate values
-        - Add an explicit section about "Aggregate Types" and move "Vector Type"
-          and "Bundle Type" under it.
+        - Add an explicit section about "Aggregate Types" and move "Vector Type" and
+          "Bundle Type" under it.
         - Move "head" and "tail" from primop_1expr_keyword to
           primop_1expr1int_keyword in the "FIRRTL Language Definition".
         - Add in-line annotation format

--- a/spec.md
+++ b/spec.md
@@ -862,32 +862,6 @@ Probe types may target `const`{.firrtl} signals, but cannot use
 `RWProbe<const T>`{.firrtl}, as constant values should never be mutated at
 runtime.
 
-## Type Alias
-
-A type alias is a mechanism to assign names to existing FIRRTL types. Type aliases
-enables their reuse across multiple declarations.
-
-```firrtl
-type WordType = UInt<32>
-type ValidType = UInt<1>
-type Data = {w: WordType, valid: ValidType, flip ready: UInt<1>}
-type AnotherWordType = UInt<32>
-
-module TypeAliasMod:
-  input in: Data
-  output out: Data
-  wire w: AnotherWordType
-  connect w, in.w
-  ...
-```
-
-The `type` declaration is globally defined and all named types exist in the same
-namespace and thus must all have a unique name. Type aliases do not share the same
-namespace as modules; hence it is allowed for type aliases to conflict with module
-names. Note that when we compare two types, the equivalence is determined solely by
-their structures. For instance types of `w`{.firrtl} and `in.w`{.firrtl} are
-equivalent in the example above even though they are different type alias.
-
 #### Width and Reset Inference
 
 Probe types do participate in global width and reset inference, but only in the
@@ -969,9 +943,10 @@ modules before its resolution.
 
 #### Invalid Input Reference
 
-When using a probe reference, the target must reside at or below the point of use
-in the design hierarchy.  Input references make it possible to create designs
-where this is not the case, and such upwards references are not supported:
+When using a probe reference, the target must reside at or below the point of
+use in the design hierarchy.  Input references make it possible to create
+designs where this is not the case, and such upwards references are not
+supported:
 
 ```firrtl
 module Foo:
@@ -1075,6 +1050,33 @@ module Top:
   node consumer_debug = read(c.out.cref); ; Consumer-side signal
 ```
 
+## Type Alias
+
+A type alias is a mechanism to assign names to existing FIRRTL types. Type
+aliases enables their reuse across multiple declarations.
+
+```firrtl
+type WordType = UInt<32>
+type ValidType = UInt<1>
+type Data = {w: WordType, valid: ValidType, flip ready: UInt<1>}
+type AnotherWordType = UInt<32>
+
+module TypeAliasMod:
+  input in: Data
+  output out: Data
+  wire w: AnotherWordType
+  connect w, in.w
+  ...
+```
+
+The `type` declaration is globally defined and all named types exist in the
+same namespace and thus must all have a unique name. Type aliases do not share
+the same namespace as modules; hence it is allowed for type aliases to conflict
+with module names. Note that when we compare two types, the equivalence is
+determined solely by their structures. For instance types of `w`{.firrtl} and
+`in.w`{.firrtl} are equivalent in the example above even though they are
+different type alias.
+
 ## Property Types
 
 FIRRTL property types represent information about the circuit that is not
@@ -1101,7 +1103,7 @@ Integer property types represent arbitrary precision signed integer values.
 
 ``` firrtl
 module Example:
-  input intProp : Integer ; an input port of Integer property type
+input intProp : Integer ; an input port of Integer property type
 ```
 
 ## Type Modifiers
@@ -4039,8 +4041,8 @@ The versioning scheme complies with
 
 Specifically,
 
-The PATCH digit is bumped upon release which only includes non-functional changes,
-such as grammar edits, further examples, and clarifications.
+The PATCH digit is bumped upon release which only includes non-functional
+changes, such as grammar edits, further examples, and clarifications.
 
 The MINOR digit is bumped for feature additions to the spec.
 
@@ -4048,5 +4050,5 @@ The MAJOR digit is bumped for backwards-incompatible changes such as features
 being removed from the spec, changing their interpretation, or new required
 features being added to the specification.
 
-In other words, any `.fir` file that was compliant with `x.y.z` will be compliant
-with `x.Y.Z`, where `Y >= y`, `z` and `Z` can be any number.
+In other words, any `.fir` file that was compliant with `x.y.z` will be
+compliant with `x.Y.Z`, where `Y >= y`, `z` and `Z` can be any number.

--- a/spec.md
+++ b/spec.md
@@ -1103,7 +1103,7 @@ Integer property types represent arbitrary precision signed integer values.
 
 ``` firrtl
 module Example:
-input intProp : Integer ; an input port of Integer property type
+  input intProp : Integer ; an input port of Integer property type
 ```
 
 ## Type Modifiers

--- a/spec.md
+++ b/spec.md
@@ -943,10 +943,9 @@ modules before its resolution.
 
 #### Invalid Input Reference
 
-When using a probe reference, the target must reside at or below the point of
-use in the design hierarchy.  Input references make it possible to create
-designs where this is not the case, and such upwards references are not
-supported:
+When using a probe reference, the target must reside at or below the point of use
+in the design hierarchy.  Input references make it possible to create designs
+where this is not the case, and such upwards references are not supported:
 
 ```firrtl
 module Foo:
@@ -1052,8 +1051,8 @@ module Top:
 
 ## Type Alias
 
-A type alias is a mechanism to assign names to existing FIRRTL types. Type
-aliases enables their reuse across multiple declarations.
+A type alias is a mechanism to assign names to existing FIRRTL types. Type aliases
+enables their reuse across multiple declarations.
 
 ```firrtl
 type WordType = UInt<32>
@@ -1069,13 +1068,12 @@ module TypeAliasMod:
   ...
 ```
 
-The `type` declaration is globally defined and all named types exist in the
-same namespace and thus must all have a unique name. Type aliases do not share
-the same namespace as modules; hence it is allowed for type aliases to conflict
-with module names. Note that when we compare two types, the equivalence is
-determined solely by their structures. For instance types of `w`{.firrtl} and
-`in.w`{.firrtl} are equivalent in the example above even though they are
-different type alias.
+The `type` declaration is globally defined and all named types exist in the same
+namespace and thus must all have a unique name. Type aliases do not share the same
+namespace as modules; hence it is allowed for type aliases to conflict with module
+names. Note that when we compare two types, the equivalence is determined solely by
+their structures. For instance types of `w`{.firrtl} and `in.w`{.firrtl} are
+equivalent in the example above even though they are different type alias.
 
 ## Property Types
 
@@ -4041,8 +4039,8 @@ The versioning scheme complies with
 
 Specifically,
 
-The PATCH digit is bumped upon release which only includes non-functional
-changes, such as grammar edits, further examples, and clarifications.
+The PATCH digit is bumped upon release which only includes non-functional changes,
+such as grammar edits, further examples, and clarifications.
 
 The MINOR digit is bumped for feature additions to the spec.
 
@@ -4050,5 +4048,5 @@ The MAJOR digit is bumped for backwards-incompatible changes such as features
 being removed from the spec, changing their interpretation, or new required
 features being added to the specification.
 
-In other words, any `.fir` file that was compliant with `x.y.z` will be
-compliant with `x.Y.Z`, where `Y >= y`, `z` and `Z` can be any number.
+In other words, any `.fir` file that was compliant with `x.y.z` will be compliant
+with `x.Y.Z`, where `Y >= y`, `z` and `Z` can be any number.


### PR DESCRIPTION
This PR fixes the location of the "Type Alias" alias, which was inserted in the middle of the "Reference Types" section. Consequently, some subsections of "Reference Types" are wrongly attached to the "Type Alias" section.

This dates back to b037c7662240450077b0c09e82cd377076412733 and it can be observed in the 3.1.0 version of the specification (see for instance subsection 7.4.0.1, "Width and Reset Inference").

Additionally, this PR enforces the 80 characters maximum width in some places.