### PR TITLE
[major] Add public modules

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -25,6 +25,7 @@
       <item>invalidate</item>
       <item>intrinsic</item>
       <item>propassign</item>
+      <item>public</item>
     </list>
     <list name="types">
       <item>UInt</item>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,7 +5,12 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
     spec:
+      - Add public modules.  Change circuits to support any number of public
+        modules which may have disjoint instance hierarchies.
     abi:
+      - Add ABI for public modules and filelist output.
+      - Changed ABI for group and ref generated files.  These now use the public
+        module and not the circuit.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 3.2.0


### PR DESCRIPTION
Add a notion of "public" modules to FIRRTL.  A public module is a module that has a defined Verilog ABI.  A user can look at a FIRRTL circuit and expect to see Verilog modules with expected ports and names after compilation.  The notion of a circuit is then expanded to allow for any number of public modules.  The instance graphs of public modules may or may not share common children. In effect, a circuit is now collection of multi-rooted instantiation trees.

Any public module that is instantiated by other modules has certain restrictions on its lowering.  It follows one of the port lowering ABIs and no information from its instantiating context(s) may be used to optimize into it.  (You cannot constant prop into a public module.)  However, it is allowable for modules which instantiate the public module to optimize through the public module.

Modify the ABI to require that all public modules produce a filelist whose name is derived from the circuit and public module.

Closes #82.
Closes #20.