### PR TITLE
[nfc] Define Circuit Components

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -599,7 +599,7 @@ since `Passthrough` is not a type.
 
 The principal type of a submodule instance is bundle type determined by its ports.
 Each port creates a field in the bundle of the same name.
-Among these fields, `input` ports are flipped, while `output` fields are unflipped.
+Among these fields, `output` ports are flipped, while `input` fields are unflipped.
 
 For example:
 

--- a/spec.md
+++ b/spec.md
@@ -541,7 +541,7 @@ For both variants of register, the type is given after the colon (`:`{.firrtl}).
 
 Semantically, registers become flip-flops in the design.
 The next value is latched on the positive edge of the clock.
-For registers without a reset, the initial value is indeterminate (see [@sec:indeterminate-values]).
+The initial value of a register is indeterminate (see [@sec:indeterminate-values]).
 
 
 ## Output Ports and Input Ports

--- a/spec.md
+++ b/spec.md
@@ -1267,10 +1267,6 @@ module MyModule :
   connect myoutput, myinput
 ```
 
-TODO: Define a notion of "connectable circuit component".
-TODO: These currently include only wires, registers, and ports.
-TODO: Every "connectable circuit component" has a "principle type" which governs what it can connect to.
-
 In order for a connection to be legal the following conditions must hold:
 
 1.  The types of the left-hand and right-hand side expressions must be equivalent (see [@sec:type-equivalence] for details).
@@ -1385,9 +1381,9 @@ connect c, d
 The empty statement is most often used as the `else`{.firrtl} branch in a conditional statement, or as a convenient placeholder for removed components during transformational passes.
 See [@sec:conditionals] for details on the conditional statement.
 
-## Wires
+## Wire
 
-TODO: Moved to circuit components
+See [@sec:wires].
 
 ## Registers
 
@@ -1402,8 +1398,6 @@ Registers may be declared without a reset using the `reg`{.firrtl} syntax and wi
 
 ### Registers without Reset
 
-TODO: Do I remove this?
-
 The following example demonstrates instantiating a register with the given name
 `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
 `myclock`{.firrtl}.
@@ -1415,8 +1409,6 @@ reg myreg: SInt, myclock
 ```
 
 ### Registers with Reset
-
-TODO: Do I remove this?
 
 A register with a reset is declared using `regreset`{.firrtl}.  A
 `regreset`{.firrtl} adds two expressions after the type and clock arguments: a

--- a/spec.md
+++ b/spec.md
@@ -1381,8 +1381,9 @@ TODO: Moved to circuit components
 
 ## Registers
 
-A register is a named stateful circuit component.
-Reads from a register return the current value of the element, writes are not visible until after a positive edges of the register's clock port.
+A register is a stateful circuit component.
+Reads from a register return the current value of the element,
+writes are not visible until after the next positive edge of the register's clock.
 
 The clock signal for a register must be of type `Clock`{.firrtl}.
 The type of a register must be a passive type (see [@sec:passive-types]) and may not be `const`{.firrtl}.
@@ -3100,8 +3101,10 @@ The flow of all other expressions are source.
 
 # Width Inference
 
-For all circuit components declared with unspecified widths, the FIRRTL compiler will infer the minimum possible width that maintains the legality of all its incoming connections.
-If a component has no incoming connections, and the width is unspecified, then an error is thrown to indicate that the width could not be inferred.
+For all circuit components declared with unspecified widths,
+the FIRRTL compiler will infer the minimum possible width that maintains the legality of all its incoming connections.
+If a circuit component has no incoming connections, and the width is unspecified,
+then an error is thrown to indicate that the width could not be inferred.
 
 For module input ports with unspecified widths, the inferred width is the minimum possible width that maintains the legality of all incoming connections to all instantiations of the module.
 

--- a/spec.md
+++ b/spec.md
@@ -492,9 +492,8 @@ Wires represent named expressions whose value is determined by FIRRTL `connect`{
 
 Example:
 
-``` firrtl
+```firrtl
 wire mywire: UInt<1>
-
 connect mywire, UInt<1>(0)
 ```
 
@@ -516,17 +515,17 @@ Optionally, registers may have a reset signal.
 On every cycle, a register will drive its current value
 and then latch the value it will take on for the next cycle.
 
-The `regreset` keyword is used to declare a register with a reset.
-The `reg` keyword is used to declare a register without a reset.
+The `regreset`{.firrtl} keyword is used to declare a register with a reset.
+The `reg`{.firrtl} keyword is used to declare a register without a reset.
 
 Examples:
 
-``` firrtl
+```firrtl
 wire myclock : Clock
 reg myreg : SInt, myclock
 ```
 
-``` firrtl
+```firrtl
 wire myclock : Clock
 reg myreg : SInt, myclock
 ```
@@ -550,7 +549,7 @@ The way a module interacts with the outside world is through its ports.
 
 Example:
 
-``` firrtl
+```firrtl
 input myinput : UInt<1>
 output myinput : SInt<8>
 ```
@@ -569,12 +568,12 @@ Example:
 inst passthrough of Passthrough
 ```
 
-This assumes you have a module named `Passthrough` declared elsewhere in the current circuit.
+This assumes you have a module named `Passthrough`{.firrtl} declared elsewhere in the current circuit.
 The keyword `of`{.firrtl} is used instead of a colon (`:`{.firrtl}).
 
 The type of a submodule instance is bundle type determined by its ports.
 Each port creates a field with the same name in the bundle.
-Among these fields, `output` ports are flipped, while `input` fields are unflipped.
+Among these fields, `output`{.firrtl} ports are flipped, while `input`{.firrtl} fields are unflipped.
 
 For example:
 
@@ -585,7 +584,7 @@ module Passthrough :
   connect out, in
 ```
 
-The type of the submodule instance `passthrough` above is thus:
+The type of the submodule instance `passthrough`{.firrtl} above is thus:
 
 ```firrtl
 { flip in : UInt<8>, out : UInt<8> }
@@ -612,7 +611,7 @@ mem mymem :
 
 The type of a memory is a bundle type derived from the declaration (see [@sec:mem]).
 
-The type named in `data-type` must be passive.
+The type named in `data-type`{.firrtl} must be passive.
 It indicates the type of the data being stored inside of the memory.
 
 See [@sec:mem] for more details.

--- a/spec.md
+++ b/spec.md
@@ -493,7 +493,7 @@ Wires represent named expressions whose value is determined by FIRRTL `connect`{
 Example:
 
 ```firrtl
-wire mywire: UInt<1>
+wire mywire : UInt<1>
 connect mywire, UInt<1>(0)
 ```
 
@@ -505,10 +505,8 @@ The type of a wire is given after the colon (`:`{.firrtl}).
 
 Registers are stateful elements of a design.
 
-Registers can be connected (see [@sec:connects]).
-The state of the register is controlled through what is connected to it.
-
-The state of a register may be any non-`const`{.firrtl} passive type (see [@sec:passive-types]).
+The state of a register is controlled through what is connected to it (see [@sec:connects]).
+The state may be any non-`const`{.firrtl} passive type (see [@sec:passive-types]).
 Registers are always associated with a clock.
 Optionally, registers may have a reset signal.
 
@@ -545,7 +543,7 @@ The initial value of a register is indeterminate (see [@sec:indeterminate-values
 
 ## Output Ports and Input Ports
 
-The way a module interacts with the outside world is through its ports.
+The way a module interacts with the outside world is through its output and input ports.
 
 Example:
 

--- a/spec.md
+++ b/spec.md
@@ -214,18 +214,12 @@ I.e., the identifier of a top-level group declared in a circuit must not conflic
 Each optional group declaration must include a string that sets the lowering convention for that group.
 The FIRRTL ABI specification defines supported lowering convention.  One such strategy is `"bind"`{.firrtl} which lowers to modules and instances which are instantiated using the SystemVerilog `bind`{.verilog} feature.
 
-The `group`{.firrtl} keyword defines optional functionality inside a module.  An
-optional group may only be defined inside a module.  An optional group must
-reference a group declared in the current circuit.  Declarations of identifiers
-and references to existing identifiers following the same lexical scoping rules
-as FIRRTL conditional statements (see: [@sec:conditional-scopes])---identifiers declared in
-the group definition may not be used outside the group while groups may refer to
-identifiers declared outside the group.  __The statements in a group are
-restricted in what identifiers they are allowed to drive.__ A statement in a
-group may drive no sinks declared outside the group _with one exception_: a
-statement in a group may drive reference types declared outside the group if the
-reference types are associated with the group in which the statement is declared
-(see: [@sec:reference-types]).
+The `group`{.firrtl} keyword defines optional functionality inside a module.
+An optional group may only be defined inside a module.
+An optional group must reference a group declared in the current circuit.
+Declarations of identifiers and references to existing identifiers following the same lexical scoping rules as FIRRTL conditional statements (see: [@sec:conditional-scopes])---identifiers declared in the group definition may not be used outside the group while groups may refer to identifiers declared outside the group.
+__The statements in a group are restricted in what identifiers they are allowed to drive.
+__ A statement in a group may drive no sinks declared outside the group _with one exception_: a statement in a group may drive reference types declared outside the group if the reference types are associated with the group in which the statement is declared (see: [@sec:reference-types]).
 
 The circuit below contains one optional group declaration, `Bar`.
 Module `Foo` contains a group definition that creates a node computed from a port defined in the scope of `Foo`.
@@ -1170,16 +1164,14 @@ module Example:
 
 ### Constant Type
 
-A constant type is a type whose value is guaranteed to be unchanging at circuit
-execution time.  Constant is a constraint on the mutability of the value, it
-does not imply a literal value at a point in the emitted design.  Constant types
-may be used in ports, wire, and nodes.  Operations on constant type are well defined.
-With any exception listed in the definition for such operations as have exceptions,
-an operation whose arguments are constant produces a constant.  An operation
-with some non-constant arguments produce a non-constant.  Constants may be
-used as the target of a connect so long as the source of the connect is itself
-constant.  These rules ensure all constants are derived from constant integer
-expressions or from constant-typed input ports of a public module.
+A constant type is a type whose value is guaranteed to be unchanging at circuit execution time.
+Constant is a constraint on the mutability of the value, it does not imply a literal value at a point in the emitted design.
+Constant types may be used in ports, wire, and nodes.
+Operations on constant type are well defined.
+With any exception listed in the definition for such operations as have exceptions, an operation whose arguments are constant produces a constant.
+An operation with some non-constant arguments produce a non-constant.
+Constants may be used as the target of a connect so long as the source of the connect is itself constant.
+These rules ensure all constants are derived from constant integer expressions or from constant-typed input ports of a public module.
 
 ``` firrtl
 const UInt<3>
@@ -1416,15 +1408,12 @@ reg myreg: SInt, myclock
 
 ### Registers with Reset
 
-A register with a reset is declared using `regreset`{.firrtl}.  A
-`regreset`{.firrtl} adds two expressions after the type and clock arguments: a
-reset signal and a reset value.  The register's value is updated with the reset
-value when the reset is asserted.  The reset signal must be a `Reset`{.firrtl},
-`UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and the type of initialization
-value must be equivalent to the declared type of the register (see
-[@sec:type-equivalence] for details).  If the reset signal is an
-`AsyncReset`{.firrtl}, then the reset value must be a constant type.  The
-behavior of the register depends on the type of the reset signal.
+A register with a reset is declared using `regreset`{.firrtl}.
+A `regreset`{.firrtl} adds two expressions after the type and clock arguments: a reset signal and a reset value.
+The register's value is updated with the reset value when the reset is asserted.
+The reset signal must be a `Reset`{.firrtl}, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and the type of initialization value must be equivalent to the declared type of the register (see [@sec:type-equivalence] for details).
+If the reset signal is an `AsyncReset`{.firrtl}, then the reset value must be a constant type.
+The behavior of the register depends on the type of the reset signal.
 `AsyncReset`{.firrtl} will immediately change the value of the register.
 `UInt<1>`{.firrtl} will not change the value of the register until the next positive edge of the clock signal (see [@sec:reset-type]).
 `Reset`{.firrtl} is an abstract reset whose behavior depends on reset inference.

--- a/spec.md
+++ b/spec.md
@@ -463,7 +463,9 @@ Any use in place of an integer is disallowed.
 # Circuit Components
 
 Circuit components are the named objects which may be contained within a module.
-They are: nodes, wires, registers, submodule instances, and ports.
+They are: nodes, wires, registers, ports, and submodule instances.
+
+TODO: What about `mem`\s?
 
 ## Nodes
 
@@ -501,15 +503,77 @@ Example:
 
 ## Registers
 
-TODO
+Registers are the stateful elements of a design.
 
-## Submodule Instances
+Registers can be connected (see [@sec:connects]).
+The state of the register is controlled through what is connected to it.
 
-TODO
+The state of a register may be any passive type (see [@sec:passive-types]) and may not be `const`{.firrtl}.
+(TODO: is the `const` restriction a consequence of the passive part or not? Why is this required?)
+(TODO: Is this true with probes and stufff?)
+Registers are always associated with a clock.
+Optionally, registers may have a reset signal. (TODO: What about an initial value?)
+
+On every cycle, a register will drive its current value and then latch the value it will take on for the next cycle.
+
+The `regreset` keyword is used to declare a register with a reset.
+The `reg` keyword is used to declare a register without a reset.
+
+Examples:
+
+``` firrtl
+wire myclock: Clock
+reg myreg: SInt, myclock
+```
+
+``` firrtl
+wire myclock: Clock
+reg myreg: SInt, myclock
+```
+```firrtl
+wire myclock: Clock
+wire myreset: UInt<1>
+wire myinit: SInt
+regreset myreg: SInt, myclock, myreset, myinit
+```
+
+Semantically, the next value is latched on the positive edge of the clock.
+Additionally, a register's initial value is indeterminate (see [@sec:indeterminate-values]).
+
 
 ## Ports
 
-TODO
+The way a module interacts with the outside world is through its ports.
+
+Example:
+
+``` firrtl
+    input myinput : UInt<1>
+    output myinput : SInt<8>
+```
+
+Ports are declared with the keywords `input` and `output`.
+The two keywords only differ in the rules for how they may be connected (see [@sec:connects]).
+
+## Submodule Instances
+
+A module in FIRRTL is allowed to contain submodules.
+Each submodule instance must be given a name.
+It must also name the FIRRTL module it is instantiating.
+
+Example:
+
+```firrtl
+inst passthrough of Passthrough
+```
+
+This assumes you have a module named `Passthrough` declared elsewhere in your FIRRTL design.
+The keyword `of` is used instead of the colon `:` since `Passthrough` is not a type.
+
+A submodule may not be connected to.
+However, a module may connect to the ports of a submodule instance.
+The rules for connecting to these ports is mirrored from the rules for how to connect to them when inside the module.
+
 
 # Types
 
@@ -1268,7 +1332,11 @@ Registers may be declared without a reset using the `reg`{.firrtl} syntax and wi
 
 ### Registers without Reset
 
-The following example demonstrates instantiating a register with the given name `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal `myclock`{.firrtl}.
+TODO: Do I remove this?
+
+The following example demonstrates instantiating a register with the given name
+`myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
+`myclock`{.firrtl}.
 
 ``` firrtl
 wire myclock: Clock
@@ -1278,12 +1346,17 @@ reg myreg: SInt, myclock
 
 ### Registers with Reset
 
-A register with a reset is declared using `regreset`{.firrtl}.
-A `regreset`{.firrtl} adds two expressions after the type and clock arguments: a reset signal and a reset value.
-The register's value is updated with the reset value when the reset is asserted.
-The reset signal must be a `Reset`{.firrtl}, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and the type of initialization value must be equivalent to the declared type of the register (see [@sec:type-equivalence] for details).
-If the reset signal is an `AsyncReset`{.firrtl}, then the reset value must be a constant type.
-The behavior of the register depends on the type of the reset signal.
+TODO: Do I remove this?
+
+A register with a reset is declared using `regreset`{.firrtl}.  A
+`regreset`{.firrtl} adds two expressions after the type and clock arguments: a
+reset signal and a reset value.  The register's value is updated with the reset
+value when the reset is asserted.  The reset signal must be a `Reset`{.firrtl},
+`UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}, and the type of initialization
+value must be equivalent to the declared type of the register (see
+[@sec:type-equivalence] for details).  If the reset signal is an
+`AsyncReset`{.firrtl}, then the reset value must be a constant type.  The
+behavior of the register depends on the type of the reset signal.
 `AsyncReset`{.firrtl} will immediately change the value of the register.
 `UInt<1>`{.firrtl} will not change the value of the register until the next positive edge of the clock signal (see [@sec:reset-type]).
 `Reset`{.firrtl} is an abstract reset whose behavior depends on reset inference.

--- a/spec.md
+++ b/spec.md
@@ -472,7 +472,6 @@ Circuit components can be connected together (see [@sec:connects]).
 Each circuit component in a module has a type ([@sec:types]).
 It is used to determine the legality of connections.
 
-
 ## Nodes
 
 Nodes are named expressions in FIRRTL.
@@ -484,7 +483,6 @@ node mynode = and(in, UInt<4>(1))
 ```
 
 The type of a node is the type of the expression given in the definition.
-
 
 ## Wires
 
@@ -499,7 +497,6 @@ connect mywire, UInt<1>(0)
 
 Unlike nodes, the type of a wire must be explicitly declared.
 The type of a wire is given after the colon (`:`{.firrtl}).
-
 
 ## Registers
 
@@ -527,6 +524,7 @@ reg myreg : SInt, myclock
 wire myclock : Clock
 reg myreg : SInt, myclock
 ```
+
 ```firrtl
 wire myclock : Clock
 wire myreset : UInt<1>
@@ -539,7 +537,6 @@ For both variants of register, the type is given after the colon (`:`{.firrtl}).
 Semantically, registers become flip-flops in the design.
 The next value is latched on the positive edge of the clock.
 The initial value of a register is indeterminate (see [@sec:indeterminate-values]).
-
 
 ## Output Ports and Input Ports
 
@@ -566,7 +563,7 @@ Example:
 inst passthrough of Passthrough
 ```
 
-This assumes you have a module named `Passthrough`{.firrtl} declared elsewhere in the current circuit.
+This assumes you have a `module`, `extmodule`, or `intmodule` named `Passthrough`{.firrtl} declared elsewhere in the current circuit.
 The keyword `of`{.firrtl} is used instead of a colon (`:`{.firrtl}).
 
 The type of a submodule instance is bundle type determined by its ports.
@@ -587,7 +584,6 @@ The type of the submodule instance `passthrough`{.firrtl} above is thus:
 ```firrtl
 { flip in : UInt<8>, out : UInt<8> }
 ```
-
 
 ## Memories
 
@@ -613,7 +609,6 @@ The type named in `data-type`{.firrtl} must be passive.
 It indicates the type of the data being stored inside of the memory.
 
 See [@sec:mem] for more details.
-
 
 # Types
 
@@ -1191,7 +1186,7 @@ It is, for example, expected that a module with a constant input port be fully c
 
 Stateful elements, such as registers and memories, may contain data of aggregate types.
 Registers with bundle types are especially common.
-However, when using bundle types in stateful elements, the notion of `flip` is meaningless.
+However, when using bundle types in stateful elements, the notion of `flip` does not make sense.
 There is no directionality to the data inside a register; the data just *is*.
 
 A passive type is a type which does not make use of `flip`.
@@ -1371,8 +1366,7 @@ See [@sec:wires].
 ## Registers
 
 A register is a stateful circuit component.
-Reads from a register return the current value of the element,
-writes are not visible until after the next positive edge of the register's clock.
+Reads from a register return the current value of the element, writes are not visible until after the next positive edge of the register's clock.
 
 The clock signal for a register must be of type `Clock`{.firrtl}.
 The type of a register must be a passive type (see [@sec:passive-types]) and may not be `const`{.firrtl}.
@@ -1381,9 +1375,7 @@ Registers may be declared without a reset using the `reg`{.firrtl} syntax and wi
 
 ### Registers without Reset
 
-The following example demonstrates instantiating a register with the given name
-`myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal
-`myclock`{.firrtl}.
+The following example demonstrates instantiating a register with the given name `myreg`{.firrtl}, type `SInt`{.firrtl}, and is driven by the clock signal `myclock`{.firrtl}.
 
 ``` firrtl
 wire myclock: Clock
@@ -3793,9 +3785,7 @@ letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
        | "o" | "p" | "q" | "r" | "s" | "t" | "u"
        | "v" | "w" | "x" | "y" | "z" ;
 
-(* Fileinfo communicates Chisel source file and line/column info *)
-linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;
-lineinfo = string, " ", linecol ;
+(* Tokens: Fileinfo *)
 info = "@" , "[" , lineinfo, { ",", lineinfo }, "]" ;
 lineinfo = string, " ", linecol ;
 linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;

--- a/spec.md
+++ b/spec.md
@@ -467,10 +467,9 @@ Circuit components are the named parts of a module corresponding to physical har
 There are seven **kinds** of circuit components.
 They are: nodes, wires, registers, output ports, input ports, submodule instances, and memories.
 
-Circuit components can be connected together in the hardware (see [@sec:connects]).
+Circuit components can be connected together (see [@sec:connects]).
 
-Each circuit component in a module is associated with a type called its type ([@sec:types]).
-This is the type of data that travels across the component.
+Each circuit component in a module has a type ([@sec:types]).
 It is used to determine the legality of connections.
 
 
@@ -490,7 +489,6 @@ The type of a node is the type of the expression given in the definition.
 ## Wires
 
 Wires represent named expressions whose value is determined by FIRRTL `connect`{.firrtl} statements (see [@sec:connects]).
-Also unlike nodes, the type of a wire must be explicitly declared.
 
 Example:
 
@@ -500,6 +498,7 @@ Example:
     connect mywire, UInt<1>(0)
 ```
 
+Unlike nodes, the type of a wire must be explicitly declared.
 The type of a wire is given after the colon (`:`{.firrtl}).
 
 

--- a/spec.md
+++ b/spec.md
@@ -1237,7 +1237,10 @@ Statements are used to describe the components within a module and how they inte
 
 ## Connects
 
-The connect statement is used to specify a physically wired connection between two circuit components.
+Circuit components can be connected together.
+This connection is both physical, as if the components were connected together with a wire,
+but also logical, allowing metadata such as probes (see [@sec:probe-types;@sec:probe])
+and properties (see [@sec:property-types]) to flow across it during elaboration.
 
 The following example demonstrates connecting a module's input port to its output port, where port `myinput`{.firrtl} is connected to port `myoutput`{.firrtl}.
 

--- a/spec.md
+++ b/spec.md
@@ -3107,10 +3107,8 @@ The flow of all other expressions are source.
 # Width Inference
 
 For all circuit components declared with unspecified widths,
-the FIRRTL compiler will infer the minimum possible width that
-maintains the legality of all its incoming connections.
-If a circuit component has no incoming connections, and the width is unspecified,
-then an error is thrown to indicate that the width could not be inferred.
+the FIRRTL compiler will infer the minimum possible width that maintains the legality of all its incoming connections.
+If a circuit component has no incoming connections, and the width is unspecified, then an error is thrown to indicate that the width could not be inferred.
 
 For module input ports with unspecified widths, the inferred width is the minimum possible width that maintains the legality of all incoming connections to all instantiations of the module.
 

--- a/spec.md
+++ b/spec.md
@@ -1239,7 +1239,8 @@ Two property types are equivalent if they are the same concrete property type.
 
 # Statements
 
-Statements are used to describe the components within a module and how they interact.
+A module body consists of a sequence of statements.
+Statements declare the circuit components and describe their connectivity.
 
 ## Connects
 

--- a/spec.md
+++ b/spec.md
@@ -1435,20 +1435,18 @@ A register is initialized with an indeterminate value (see [@sec:indeterminate-v
 
 ## Invalidates
 
-An invalidate statement is used to indicate that a circuit component contains indeterminate values (see [@sec:indeterminate-values]).
+The `invalidate`{.firrtl} statement allows a circuit component to be left uninitialized or only partially initialized.
+The uninitialized part is left with an indeterminate value (see [@sec:indeterminate-values]).
+
 It is specified as follows:
 
 ``` firrtl
 wire w: UInt
 invalidate w
 ```
-
-Invalidate statements can be applied to any circuit component of any type.
-This allows the invalidate statement to be applied to any component,
-to explicitly ignore initialization coverage errors.
-
-The following example demonstrates the effect of invalidating a variety of circuit components with aggregate types.
-See [@sec:the-invalidate-algorithm] for details on the algorithm for determining what is invalidated.
+The following example demonstrates the effect of invalidating a variety of
+circuit components with aggregate types. See [@sec:the-invalidate-algorithm] for
+details on the algorithm for determining what is invalidated.
 
 ``` firrtl
 module MyModule :

--- a/spec.md
+++ b/spec.md
@@ -1114,15 +1114,17 @@ module Example:
 
 ### Constant Type
 
-A constant type is a type whose value is guaranteed to be unchanging at circuit execution time.
-Constant is a constraint on the mutability of the value, it does not imply a literal value at a point in the emitted design.
-Constant types may be used in ports, wire, nodes, and generally anywhere a non-constant type is usable.
-Operations on constant type are well defined.
-As a general rule (with any exception listed in the definition for such operations as have exceptions), an operation whose arguments are constant produces a constant.
-An operation with some non-constant arguments produce a non-constant.
-Constants can be used in any context with a source flow which allows a non-constant.
-Constants may be used as the target of a connect so long as the source of the connect is itself constant.
-These rules ensure all constants are derived from constant integer expressions or from constant-typed input ports of a public module.
+A constant type is a type whose value is guaranteed to be unchanging at circuit
+execution time.  Constant is a constraint on the mutability of the value, it
+does not imply a literal value at a point in the emitted design.  Constant types
+may be used in ports, wire, and nodes.  Operations on constant type are well defined.
+With any exception listed in the definition for such operations as have exceptions,
+an operation whose arguments are constant produces a constant.  An operation
+with some non-constant arguments produce a non-constant.  Constants can be used
+in any context with a source flow which allows a non-constant.  Constants may be
+used as the target of a connect so long as the source of the connect is itself
+constant.  These rules ensure all constants are derived from constant integer
+expressions or from constant-typed input ports of a public module.
 
 ``` firrtl
 const UInt<3>

--- a/spec.md
+++ b/spec.md
@@ -2509,7 +2509,6 @@ The data value expression may be omitted when the data type is `UInt<0>(0)`{.fir
 ## References
 
 A reference is simply a name that refers to a previously declared circuit component.
-It may refer to a module port, node, wire, register, instance, or memory.
 
 The following example connects a reference expression `in`{.firrtl}, referring to the previously declared port `in`{.firrtl}, to the reference expression `out`{.firrtl}, referring to the previously declared port `out`{.firrtl}.
 

--- a/spec.md
+++ b/spec.md
@@ -599,7 +599,7 @@ Example:
 
 ```firrtl
 mem mymem :
-  data-type => {real:SInt<16>, imag:SInt<16>}
+  data-type => { real:SInt<16>, imag:SInt<16> }
   depth => 256
   reader => r1
   reader => r2

--- a/spec.md
+++ b/spec.md
@@ -1176,16 +1176,23 @@ It is, for example, expected that a module with a constant input port be fully c
 
 ## Passive Types
 
-It is inappropriate for some circuit components to be declared with a type that allows for data to flow in both directions.
-For example, all sub-elements in a memory should flow in the same direction.
-These components are restricted to only have a passive type.
+Stateful elements, such as registers and memories, may contain data of aggregate types.
+Registers with bundle types are especially common.
+However, when using bundle types in stateful elements, the notion of `flip` is meaningless.
+There is no directionality to the data inside a register; the data just is.
 
-Intuitively, a passive type is a type where all data flows in the same direction, and is defined to be a type that recursively contains no fields with flipped orientations.
-Thus all ground types are passive types.
-Vector types are passive if their element type is passive.
-And bundle types are passive if no fields are flipped and if all field types are passive.
+A passive type is a which does not make use of `flip`.
+More precisely, a passive type is defined recursively:
 
-All property types are passive.
+* All ground types are passive.
+* Probe types are passive.
+* Properties types are passive.
+* A vector type is passive if and only if the element type is passive.
+* A bundle type is passive if and only if it contains no field which is marked `flip` and the type of each field is passive.
+* Enums are passive if and only if each of their variants is passive. (TODO: Is this the proper terminology?)
+
+Registers and memories may only be parametrized over passive types.
+
 
 ## Principal Types of Circuit Components
 

--- a/spec.md
+++ b/spec.md
@@ -540,7 +540,7 @@ regreset myreg : SInt, myclock, myreset, myinit
 For both variants of register, the type is given after the colon (`:`{.firrtl}).
 
 Semantically, registers become flip-flops in the design.
-The the next value is latched on the positive edge of the clock.
+The next value is latched on the positive edge of the clock.
 For registers without a reset, the initial value is indeterminate (see [@sec:indeterminate-values]).
 
 
@@ -551,21 +551,17 @@ The way a module interacts with the outside world is through its ports.
 Example:
 
 ``` firrtl
-    input myinput : UInt<1>
-    output myinput : SInt<8>
+  input myinput : UInt<1>
+  output myinput : SInt<8>
 ```
-
-Ports are declared with the keywords `input` and `output`.
-The two keywords only differ in the rules for how they may be connected (see [@sec:connects]).
 
 For both variants of port, the type is given after the colon (`:`{.firrtl}).
 
+The two kinds of ports differ in the rules for how they may be connected (see [@sec:connects]).
 
 ## Submodule Instances
 
-A module in FIRRTL is allowed to contain submodules.
-Each submodule instance must be given a name.
-It must also name the FIRRTL module or external module it is instantiating.
+A module in FIRRTL may contain submodules.
 
 Example:
 
@@ -574,10 +570,10 @@ inst passthrough of Passthrough
 ```
 
 This assumes you have a module named `Passthrough` declared elsewhere in your FIRRTL design.
-The keyword `of`{.firrtl} is used instead of the colon (`:`{.firrtl}) since `Passthrough` is not a type.
+The keyword `of`{.firrtl} is used instead of a colon (`:`{.firrtl}).
 
 The type of a submodule instance is bundle type determined by its ports.
-Each port creates a field in the bundle of the same name.
+Each port creates a field with the same name in the bundle.
 Among these fields, `output` ports are flipped, while `input` fields are unflipped.
 
 For example:

--- a/spec.md
+++ b/spec.md
@@ -569,7 +569,7 @@ Example:
 inst passthrough of Passthrough
 ```
 
-This assumes you have a module named `Passthrough` declared elsewhere in your FIRRTL design.
+This assumes you have a module named `Passthrough` declared elsewhere in the current circuit.
 The keyword `of`{.firrtl} is used instead of a colon (`:`{.firrtl}).
 
 The type of a submodule instance is bundle type determined by its ports.

--- a/spec.md
+++ b/spec.md
@@ -463,9 +463,7 @@ Any use in place of an integer is disallowed.
 # Circuit Components
 
 Circuit components are the named objects which may be contained within a module.
-They are: nodes, wires, registers, ports, and submodule instances.
-
-TODO: What about `mem`s?
+They are: nodes, wires, registers, ports, submodule instances, and memories.
 
 ## Nodes
 
@@ -568,10 +566,35 @@ inst passthrough of Passthrough
 This assumes you have a module named `Passthrough` declared elsewhere in your FIRRTL design.
 The keyword `of` is used instead of the colon `:` since `Passthrough` is not a type.
 
-A submodule may not be connected to.
-However, a module may connect to the ports of a submodule instance.
-The rules for connecting to these ports is mirrored from the rules for how to connect to them when inside the module.
-TODO: Does `inst` require that the thing after the `of` is a FIRRTL `module`? Can it be a `mem` or an `extmodule`?
+The principal type of a submodule instance is bundle type determined by its ports.
+
+
+## Memories
+
+Memories are large stateful elements of a design.
+
+Example:
+
+```firrtl
+mem mymem :
+  data-type => {real:SInt<16>, imag:SInt<16>}
+  depth => 256
+  reader => r1
+  reader => r2
+  writer => w
+  read-latency => 0
+  write-latency => 1
+  read-under-write => undefined
+```
+
+The principal type of a memory (see [@sec:principal-types-of-circuit-components])
+is a bundle type derived from the declaration. [@sec:memories]
+
+The type named in `data-type` must be passive.
+It indicates the type of the data being stored inside of the memory.
+
+TODO: How much detail to go into here? CF the other memories section.
+TODO: Will that @sec hyperlink work if there are two sections called the same thing?
 
 
 # Types

--- a/spec.md
+++ b/spec.md
@@ -2424,7 +2424,13 @@ module Example:
 
 # Expressions
 
-FIRRTL expressions are used for creating constant integers, for creating literal property type expressions, for referring to a declared circuit component, for statically and dynamically accessing a nested element within a component, for creating multiplexers, for performing primitive operations, and for reading a remote reference to a probe.
+FIRRTL expressions are used for creating constant integers,
+for creating literal property type expressions,
+for referencing a circuit component,
+for statically and dynamically accessing a nested element within a component,
+for creating multiplexers,
+for performing primitive operations, and
+for reading a remote reference to a probe.
 
 ## Constant Integer Expressions
 

--- a/spec.md
+++ b/spec.md
@@ -473,8 +473,7 @@ Circuit components are the named parts of a module corresponding to physical har
 There are six **kinds** of circuit components.
 They are: nodes, wires, registers, ports, submodule instances, and memories.
 
-We show how the circuit components are wired together in the hardware
-through connections (see [@sec:connects]).
+We use connections to wire circuit components together in the hardware (see [@sec:connects]).
 
 Each circuit component in a module is associated
 with a type called its **principal type** ([@sec:types]).
@@ -1230,7 +1229,7 @@ More precisely, a passive type is defined recursively:
 
 * All ground types are passive.
 * All probe types are passive.
-* All properties types are passive.
+* All property types are passive.
 * A vector type is passive if and only if the element type is passive.
 * A bundle type is passive if and only if it contains no field which is marked `flip`
   and the type of each field is passive.

--- a/spec.md
+++ b/spec.md
@@ -473,18 +473,17 @@ Circuit components are the named parts of a module corresponding to physical har
 There are seven **kinds** of circuit components.
 They are: nodes, wires, registers, output ports, input ports, submodule instances, and memories.
 
-We use connections to wire circuit components together in the hardware (see [@sec:connects]).
+Circuit components can be connected together in the hardware (see [@sec:connects]).
 
 Each circuit component in a module is associated
 with a type called its type ([@sec:types]).
-This is the type of data that flows through the component.
+This is the type of data that travels across the component.
 It is used to determine the legality of connections.
 
 
 ## Nodes
 
 Nodes are named expressions in FIRRTL.
-They represent a small piece of combinational logic.
 
 Example:
 
@@ -492,24 +491,14 @@ Example:
     node mynode = and(in, UInt<4>(1))
 ```
 
-The type of a node is the inferred type of the expression given in the definition.
-
-The value of a node is determined by the expression given in the definition.
-The type of a node (see [@sec:types-of-circuit-components])
-is the inferred type of this expression.
-
-The defining expression may reference circuit components defines
-*above* the declaration of the node itself.
-It may not reference the node being define.
-Similarly, it may not reference circuit components defined after it.
+The type of a node is the type of the expression given in the definition.
 
 
 ## Wires
 
 Wires represent named expressions whose value is determined
 by FIRRTL `connect`{.firrtl} statements (see [@sec:connects]).
-Also unlike nodes, the type of a wire must be explicitly declared,
-since it cannot be inferred from the value of the definition.
+Also unlike nodes, the type of a wire must be explicitly declared.
 
 Example:
 
@@ -524,7 +513,7 @@ The type of a wire is given after the colon (`:`{.firrtl}).
 
 ## Registers
 
-Registers are small stateful elements of a design.
+Registers are stateful elements of a design.
 
 Registers can be connected (see [@sec:connects]).
 The state of the register is controlled through what is connected to it.

--- a/spec.md
+++ b/spec.md
@@ -468,10 +468,19 @@ Any use in place of an integer is disallowed.
 
 # Circuit Components
 
-Circuit components are the named objects which may be contained within a module.
+Circuit components are the named parts of a module corresponding to physical hardware.
 
-There are six kinds of circuit components.
+There are six **kinds** of circuit components.
 They are: nodes, wires, registers, ports, submodule instances, and memories.
+
+We show how the circuit components are wired together in the hardware
+through connections (see [@sec:connects]).
+
+Each circuit component in a module is associated
+with a type called its **principal type** ([@sec:types]).
+This is the type of data that flows through the component.
+It is used to determine the legality of connections.
+
 
 ## Nodes
 
@@ -483,6 +492,8 @@ Example:
 ```firrtl
     node mynode = and(in, UInt<4>(1))
 ```
+
+The principal type of a node is the inferred type of the expression given in the definition.
 
 The value of a node is determined by the expression given in the definition.
 The principal type of a node (see [@sec:principal-types-of-circuit-components])
@@ -509,6 +520,9 @@ Example:
     connect mywire, UInt<1>(0)
 ```
 
+The principal type of a wire is given after the colon (`:`{.firrtl}).
+
+
 ## Registers
 
 Registers are small stateful elements of a design.
@@ -529,20 +543,22 @@ The `reg` keyword is used to declare a register without a reset.
 Examples:
 
 ``` firrtl
-wire myclock: Clock
-reg myreg: SInt, myclock
+wire myclock : Clock
+reg myreg : SInt, myclock
 ```
 
 ``` firrtl
-wire myclock: Clock
-reg myreg: SInt, myclock
+wire myclock : Clock
+reg myreg : SInt, myclock
 ```
 ```firrtl
-wire myclock: Clock
-wire myreset: UInt<1>
-wire myinit: SInt
-regreset myreg: SInt, myclock, myreset, myinit
+wire myclock : Clock
+wire myreset : UInt<1>
+wire myinit : SInt
+regreset myreg : SInt, myclock, myreset, myinit
 ```
+
+For both variants of register, the principal type is given after the colon (`:`{.firrtl}).
 
 Semantically, registers become flip-flops in the design.
 The the next value is latched on the positive edge of the clock.
@@ -563,6 +579,9 @@ Example:
 Ports are declared with the keywords `input` and `output`.
 The two keywords only differ in the rules for how they may be connected (see [@sec:connects]).
 
+For both variants of port, the principal type is given after the colon (`:`{.firrtl}).
+
+
 ## Submodule Instances
 
 A module in FIRRTL is allowed to contain submodules.
@@ -576,9 +595,27 @@ inst passthrough of Passthrough
 ```
 
 This assumes you have a module named `Passthrough` declared elsewhere in your FIRRTL design.
-The keyword `of` is used instead of the colon (`:`) since `Passthrough` is not a type.
+The keyword `of`{.firrtl} is used instead of the colon (`:`{.firrtl})
+since `Passthrough` is not a type.
 
 The principal type of a submodule instance is bundle type determined by its ports.
+Each port creates a field in the bundle of the same name.
+Among these fields, `input` ports are flipped, while `output` fields are unflipped.
+
+For example:
+
+```firrtl
+module Passthrough :
+  input in : UInt<8>
+  output out : UInt<8>
+  connect out, in
+```
+
+The principal type of the submodule instance `passthrough` above is thus:
+
+```firrtl
+{ flip in : UInt<8>, out : UInt<8> }
+```
 
 
 ## Memories
@@ -599,8 +636,7 @@ mem mymem :
   read-under-write => undefined
 ```
 
-The principal type of a memory (see [@sec:principal-types-of-circuit-components])
-is a bundle type derived from the declaration (see [@sec:mem]).
+The principal type of a memory is a bundle type derived from the declaration (see [@sec:mem]).
 
 The type named in `data-type` must be passive.
 It indicates the type of the data being stored inside of the memory.
@@ -1202,30 +1238,6 @@ More precisely, a passive type is defined recursively:
 
 Registers and memories may only be parametrized over passive types.
 
-
-## Principal Types of Circuit Components
-
-Each circuit component in a module is associated to a type called its principal type.
-This is the type of data that flows through the component.
-It is used to determine the legality of connections (see [@sec:connects]).
-
-The term "principal type" is used to emphasize it is the FIRRTL type ([@sec:types])
-associated with a circuit component.
-The term is meant to distinguish it from the kind of component.
-(i.e., nodes, wires, registers, ports, submodule instances, and memories).
-
-For wires, registers, ports, the principal component is declared after the colon (`:`)
-when the circuit component is declared.
-
-For nodes, the principal type is inferred from the type of the expression on the left hand side
-of the equals sign (`=`) when the node is declared.
-
-For submodule instances, the principal type is a bundle type determined by the ports it contains.
-Each `output` port introduces a new field with matching name and type.
-Each `input` port indtroduces a new field with matching name and type, which which is is flipped.
-
-The principal type of memories is a bundle type.
-The details are given in `[@sec:mem]`.
 
 ## Type Equivalence
 

--- a/spec.md
+++ b/spec.md
@@ -218,8 +218,8 @@ The `group`{.firrtl} keyword defines optional functionality inside a module.
 An optional group may only be defined inside a module.
 An optional group must reference a group declared in the current circuit.
 Declarations of identifiers and references to existing identifiers following the same lexical scoping rules as FIRRTL conditional statements (see: [@sec:conditional-scopes])---identifiers declared in the group definition may not be used outside the group while groups may refer to identifiers declared outside the group.
-__The statements in a group are restricted in what identifiers they are allowed to drive.
-__ A statement in a group may drive no sinks declared outside the group _with one exception_: a statement in a group may drive reference types declared outside the group if the reference types are associated with the group in which the statement is declared (see: [@sec:reference-types]).
+The statements in a group are restricted in what identifiers they are allowed to drive.
+A statement in a group may drive no sinks declared outside the group _with one exception_: a statement in a group may drive reference types declared outside the group if the reference types are associated with the group in which the statement is declared (see: [@sec:reference-types]).
 
 The circuit below contains one optional group declaration, `Bar`.
 Module `Foo` contains a group definition that creates a node computed from a port defined in the scope of `Foo`.

--- a/spec.md
+++ b/spec.md
@@ -469,8 +469,7 @@ They are: nodes, wires, registers, output ports, input ports, submodule instance
 
 Circuit components can be connected together in the hardware (see [@sec:connects]).
 
-Each circuit component in a module is associated
-with a type called its type ([@sec:types]).
+Each circuit component in a module is associated with a type called its type ([@sec:types]).
 This is the type of data that travels across the component.
 It is used to determine the legality of connections.
 
@@ -490,8 +489,7 @@ The type of a node is the type of the expression given in the definition.
 
 ## Wires
 
-Wires represent named expressions whose value is determined
-by FIRRTL `connect`{.firrtl} statements (see [@sec:connects]).
+Wires represent named expressions whose value is determined by FIRRTL `connect`{.firrtl} statements (see [@sec:connects]).
 Also unlike nodes, the type of a wire must be explicitly declared.
 
 Example:
@@ -577,8 +575,7 @@ inst passthrough of Passthrough
 ```
 
 This assumes you have a module named `Passthrough` declared elsewhere in your FIRRTL design.
-The keyword `of`{.firrtl} is used instead of the colon (`:`{.firrtl})
-since `Passthrough` is not a type.
+The keyword `of`{.firrtl} is used instead of the colon (`:`{.firrtl}) since `Passthrough` is not a type.
 
 The type of a submodule instance is bundle type determined by its ports.
 Each port creates a field in the bundle of the same name.

--- a/spec.md
+++ b/spec.md
@@ -462,7 +462,7 @@ Any use in place of an integer is disallowed.
 
 # Circuit Components
 
-Circuit components are the named parts of a module corresponding to physical hardware.
+Circuit components are the named parts of a module corresponding to hardware.
 
 There are seven **kinds** of circuit components.
 They are: nodes, wires, registers, output ports, input ports, submodule instances, and memories.

--- a/spec.md
+++ b/spec.md
@@ -488,15 +488,18 @@ The value of a node is determined by the expression given in the definition.
 The principal type of a node (see [@sec:principal-types-of-circuit-components])
 is the inferred type of this expression.
 
-The defining expression may reference circuit components defines *above* the declaration of the node itself.
+The defining expression may reference circuit components defines
+*above* the declaration of the node itself.
 It may not reference the node being define.
 Similarly, it may not reference circuit components defined after it.
 
 
 ## Wires
 
-Wires represent named expressions whose value is determined by FIRRTL `connect`{.firrtl} statements (see [@sec:connects]).
-Also unlike nodes, the type of a wire must be explicitly declared, since it cannot be inferred from the value of the definition.
+Wires represent named expressions whose value is determined
+by FIRRTL `connect`{.firrtl} statements (see [@sec:connects]).
+Also unlike nodes, the type of a wire must be explicitly declared,
+since it cannot be inferred from the value of the definition.
 
 Example:
 
@@ -517,7 +520,8 @@ The state of a register may be any non-`const`{.firrtl} passive type (see [@sec:
 Registers are always associated with a clock.
 Optionally, registers may have a reset signal.
 
-On every cycle, a register will drive its current value and then latch the value it will take on for the next cycle.
+On every cycle, a register will drive its current value
+and then latch the value it will take on for the next cycle.
 
 The `regreset` keyword is used to declare a register with a reset.
 The `reg` keyword is used to declare a register without a reset.
@@ -1192,7 +1196,8 @@ More precisely, a passive type is defined recursively:
 * All probe types are passive.
 * All properties types are passive.
 * A vector type is passive if and only if the element type is passive.
-* A bundle type is passive if and only if it contains no field which is marked `flip` and the type of each field is passive.
+* A bundle type is passive if and only if it contains no field which is marked `flip`
+  and the type of each field is passive.
 * An enum type is passive if and only if the type of each of its variants is passive.
 
 Registers and memories may only be parametrized over passive types.
@@ -1437,7 +1442,8 @@ A register is initialized with an indeterminate value (see [@sec:indeterminate-v
 
 ## Invalidates
 
-The `invalidate`{.firrtl} statement allows a circuit component to be left uninitialized or only partially initialized.
+The `invalidate`{.firrtl} statement allows a circuit component to be left uninitialized
+or only partially initialized.
 The uninitialized part is left with an indeterminate value (see [@sec:indeterminate-values]).
 
 It is specified as follows:
@@ -1700,13 +1706,17 @@ Registers do not need to be connected to under all conditions, as it will keep i
 
 ### Conditional Scopes
 
-Conditional statements create a new *conditional scope* within each of its `when`{.firrtl} and `else`{.firrtl} branches.
+Conditional statements create a new *conditional scope* within each
+of its `when`{.firrtl} and `else`{.firrtl} branches.
 
 Circuit components may be declared locally within a conditional scope.
-The name given to a circuit component declared this way must still be unique across all circuit components declared the module (see [@sec:namespaces]).
-This differs from the behavior in most programming languages, where variables in a local scope can shadow variables declared outside that scope.
+The name given to a circuit component declared this way must still be unique
+across all circuit components declared the module (see [@sec:namespaces]).
+This differs from the behavior in most programming languages,
+where variables in a local scope can shadow variables declared outside that scope.
 
-A circuit components declared locally within a conditional scope may only be connected to within that scope.
+A circuit components declared locally within a conditional scope
+may only be connected to within that scope.
 
 
 ### Conditional Last Connect Semantics
@@ -3108,7 +3118,8 @@ The flow of all other expressions are source.
 # Width Inference
 
 For all circuit components declared with unspecified widths,
-the FIRRTL compiler will infer the minimum possible width that maintains the legality of all its incoming connections.
+the FIRRTL compiler will infer the minimum possible width that
+maintains the legality of all its incoming connections.
 If a circuit component has no incoming connections, and the width is unspecified,
 then an error is thrown to indicate that the width could not be inferred.
 

--- a/spec.md
+++ b/spec.md
@@ -214,12 +214,18 @@ I.e., the identifier of a top-level group declared in a circuit must not conflic
 Each optional group declaration must include a string that sets the lowering convention for that group.
 The FIRRTL ABI specification defines supported lowering convention.  One such strategy is `"bind"`{.firrtl} which lowers to modules and instances which are instantiated using the SystemVerilog `bind`{.verilog} feature.
 
-The `group`{.firrtl} keyword defines optional functionality inside a module.
-An optional group may only be defined inside a module.
-An optional group must reference a group declared in the current circuit.
-Declarations of identifiers and references to existing identifiers following the same lexical scoping rules as FIRRTL conditional statements (see: [@sec:scoping])---identifiers declared in the group definition may not be used outside the group while groups may refer to identifiers declared outside the group.
-__The statements in a group are restricted in what identifiers they are allowed to drive.__
-A statement in a group may drive no sinks declared outside the group _with one exception_: a statement in a group may drive reference types declared outside the group if the reference types are associated with the group in which the statement is declared (see: [@sec:reference-types]).
+The `group`{.firrtl} keyword defines optional functionality inside a module.  An
+optional group may only be defined inside a module.  An optional group must
+reference a group declared in the current circuit.  Declarations of identifiers
+and references to existing identifiers following the same lexical scoping rules
+as FIRRTL conditional statements (see: [@sec:conditional-scopes])---identifiers declared in
+the group definition may not be used outside the group while groups may refer to
+identifiers declared outside the group.  __The statements in a group are
+restricted in what identifiers they are allowed to drive.__ A statement in a
+group may drive no sinks declared outside the group _with one exception_: a
+statement in a group may drive reference types declared outside the group if the
+reference types are associated with the group in which the statement is declared
+(see: [@sec:reference-types]).
 
 The circuit below contains one optional group declaration, `Bar`.
 Module `Foo` contains a group definition that creates a node computed from a port defined in the scope of `Foo`.
@@ -1649,8 +1655,10 @@ match x:
 
 ### Nested Declarations
 
-If a component is declared within a conditional statement, connections to the component are unaffected by the condition.
-In the following example, register `myreg1`{.firrtl} is always connected to `a`{.firrtl}, and register `myreg2`{.firrtl} is always connected to `b`{.firrtl}.
+If a circuit component is declared within a conditional statement,
+connections to the it are unaffected by the condition.
+In the following example, register `myreg1`{.firrtl} is always connected to `a`{.firrtl},
+and register `myreg2`{.firrtl} is always connected to `b`{.firrtl}.
 
 ``` firrtl
 module MyModule :
@@ -1688,11 +1696,16 @@ This is an illegal FIRRTL circuit and an error will be thrown during compilation
 All wires, memory ports, instance ports, and module ports that can be connected to must be connected to under all conditions.
 Registers do not need to be connected to under all conditions, as it will keep its previous value if unconnected.
 
-### Scoping
+### Conditional Scopes
 
-The conditional statement creates a new *scope* within each of its `when`{.firrtl} and `else`{.firrtl} branches.
-It is an error to refer to any component declared within a branch after the branch has ended.
-As mention in [@sec:namespaces], circuit component declarations in a module must be unique within the module's flat namespace; this means that shadowing a component in an enclosing scope with a component of the same name inside a conditional statement is not allowed.
+Conditional statements create a new *conditional scope* within each of its `when`{.firrtl} and `else`{.firrtl} branches.
+
+Circuit components may be declared locally within a conditional scope.
+The name given to a circuit component declared this way must still be unique across all circuit components declared the module (see [@sec:namespaces]).
+This differs from the behavior in most programming languages, where variables in a local scope can shadow variables declared outside that scope.
+
+A circuit components declared locally within a conditional scope may only be connected to within that scope.
+
 
 ### Conditional Last Connect Semantics
 

--- a/spec.md
+++ b/spec.md
@@ -476,7 +476,7 @@ They are: nodes, wires, registers, output ports, input ports, submodule instance
 We use connections to wire circuit components together in the hardware (see [@sec:connects]).
 
 Each circuit component in a module is associated
-with a type called its **principal type** ([@sec:types]).
+with a type called its type ([@sec:types]).
 This is the type of data that flows through the component.
 It is used to determine the legality of connections.
 
@@ -492,10 +492,10 @@ Example:
     node mynode = and(in, UInt<4>(1))
 ```
 
-The principal type of a node is the inferred type of the expression given in the definition.
+The type of a node is the inferred type of the expression given in the definition.
 
 The value of a node is determined by the expression given in the definition.
-The principal type of a node (see [@sec:principal-types-of-circuit-components])
+The type of a node (see [@sec:types-of-circuit-components])
 is the inferred type of this expression.
 
 The defining expression may reference circuit components defines
@@ -519,7 +519,7 @@ Example:
     connect mywire, UInt<1>(0)
 ```
 
-The principal type of a wire is given after the colon (`:`{.firrtl}).
+The type of a wire is given after the colon (`:`{.firrtl}).
 
 
 ## Registers
@@ -557,7 +557,7 @@ wire myinit : SInt
 regreset myreg : SInt, myclock, myreset, myinit
 ```
 
-For both variants of register, the principal type is given after the colon (`:`{.firrtl}).
+For both variants of register, the type is given after the colon (`:`{.firrtl}).
 
 Semantically, registers become flip-flops in the design.
 The the next value is latched on the positive edge of the clock.
@@ -578,7 +578,7 @@ Example:
 Ports are declared with the keywords `input` and `output`.
 The two keywords only differ in the rules for how they may be connected (see [@sec:connects]).
 
-For both variants of port, the principal type is given after the colon (`:`{.firrtl}).
+For both variants of port, the type is given after the colon (`:`{.firrtl}).
 
 
 ## Submodule Instances
@@ -597,7 +597,7 @@ This assumes you have a module named `Passthrough` declared elsewhere in your FI
 The keyword `of`{.firrtl} is used instead of the colon (`:`{.firrtl})
 since `Passthrough` is not a type.
 
-The principal type of a submodule instance is bundle type determined by its ports.
+The type of a submodule instance is bundle type determined by its ports.
 Each port creates a field in the bundle of the same name.
 Among these fields, `output` ports are flipped, while `input` fields are unflipped.
 
@@ -610,7 +610,7 @@ module Passthrough :
   connect out, in
 ```
 
-The principal type of the submodule instance `passthrough` above is thus:
+The type of the submodule instance `passthrough` above is thus:
 
 ```firrtl
 { flip in : UInt<8>, out : UInt<8> }
@@ -635,7 +635,7 @@ mem mymem :
   read-under-write => undefined
 ```
 
-The principal type of a memory is a bundle type derived from the declaration (see [@sec:mem]).
+The type of a memory is a bundle type derived from the declaration (see [@sec:mem]).
 
 The type named in `data-type` must be passive.
 It indicates the type of the data being stored inside of the memory.

--- a/spec.md
+++ b/spec.md
@@ -1203,6 +1203,10 @@ module MyModule :
   connect myoutput, myinput
 ```
 
+TODO: Define a notion of "connectable circuit component".
+TODO: These currently include only wires, registers, and ports.
+TODO: Every "connectable circuit component" has a "principle type" which governs what it can connect to.
+
 In order for a connection to be legal the following conditions must hold:
 
 1.  The types of the left-hand and right-hand side expressions must be equivalent (see [@sec:type-equivalence] for details).

--- a/spec.md
+++ b/spec.md
@@ -1216,13 +1216,13 @@ There is no directionality to the data inside a register; the data just *is*.
 A passive type is a which does not make use of `flip`.
 More precisely, a passive type is defined recursively:
 
-* All ground types are passive.
-* All probe types are passive.
-* All property types are passive.
-* A vector type is passive if and only if the element type is passive.
-* A bundle type is passive if and only if it contains no field which is marked `flip`
+- All ground types are passive.
+- All probe types are passive.
+- All property types are passive.
+- A vector type is passive if and only if the element type is passive.
+- A bundle type is passive if and only if it contains no field which is marked `flip`
   and the type of each field is passive.
-* An enum type is passive if and only if the type of each of its variants is passive.
+- An enum type is passive if and only if the type of each of its variants is passive.
 
 Registers and memories may only be parametrized over passive types.
 

--- a/spec.md
+++ b/spec.md
@@ -594,13 +594,12 @@ mem mymem :
 ```
 
 The principal type of a memory (see [@sec:principal-types-of-circuit-components])
-is a bundle type derived from the declaration. [@sec:memories]
+is a bundle type derived from the declaration (see [@sec:mem]).
 
 The type named in `data-type` must be passive.
 It indicates the type of the data being stored inside of the memory.
 
-TODO: How much detail to go into here? CF the other memories section.
-TODO: Will that @sec hyperlink work if there are two sections called the same thing?
+See [@sec:mem] for more details.
 
 
 # Types
@@ -1182,7 +1181,7 @@ It is, for example, expected that a module with a constant input port be fully c
 Stateful elements, such as registers and memories, may contain data of aggregate types.
 Registers with bundle types are especially common.
 However, when using bundle types in stateful elements, the notion of `flip` is meaningless.
-There is no directionality to the data inside a register; the data just is.
+There is no directionality to the data inside a register; the data just *is*.
 
 A passive type is a which does not make use of `flip`.
 More precisely, a passive type is defined recursively:
@@ -1242,7 +1241,7 @@ Statements declare the circuit components and describe their connectivity.
 ## Connects
 
 Circuit components can be connected together.
-This connection is both physical, as if the components were connected together with a wire,
+This connection can be both physical, as if the components were connected together with a wire,
 but also logical, allowing metadata such as probes (see [@sec:probe-types;@sec:probe])
 and properties (see [@sec:property-types]) to flow across it during elaboration.
 
@@ -1653,7 +1652,7 @@ match x:
 ### Nested Declarations
 
 If a circuit component is declared within a conditional statement,
-connections to the it are unaffected by the condition.
+connections to it are unaffected by the condition.
 In the following example, register `myreg1`{.firrtl} is always connected to `a`{.firrtl},
 and register `myreg2`{.firrtl} is always connected to `b`{.firrtl}.
 
@@ -1805,7 +1804,7 @@ connect w.a, mux(c, y, x.a)
 connect w.b, x.b
 ```
 
-## Memories
+## Mem
 
 A memory is an abstract representation of a hardware memory.
 It is characterized by the following parameters.

--- a/spec.md
+++ b/spec.md
@@ -469,6 +469,7 @@ Any use in place of an integer is disallowed.
 # Circuit Components
 
 Circuit components are the named objects which may be contained within a module.
+There are six kinds of circuit components.
 They are: nodes, wires, registers, ports, submodule instances, and memories.
 
 ## Nodes
@@ -570,7 +571,7 @@ inst passthrough of Passthrough
 ```
 
 This assumes you have a module named `Passthrough` declared elsewhere in your FIRRTL design.
-The keyword `of` is used instead of the colon `:` since `Passthrough` is not a type.
+The keyword `of` is used instead of the colon (`:`) since `Passthrough` is not a type.
 
 The principal type of a submodule instance is bundle type determined by its ports.
 
@@ -1191,7 +1192,7 @@ More precisely, a passive type is defined recursively:
 * Properties types are passive.
 * A vector type is passive if and only if the element type is passive.
 * A bundle type is passive if and only if it contains no field which is marked `flip` and the type of each field is passive.
-* Enums are passive if and only if each of their variants is passive. (TODO: Is this the proper terminology?)
+* An enum is passive if and only if the type of each of its variants is passive.
 
 Registers and memories may only be parametrized over passive types.
 
@@ -1200,14 +1201,25 @@ Registers and memories may only be parametrized over passive types.
 
 Each circuit component in a module is associated to a type called its principal type.
 This is the type of data that flows through the component.
+It is used to determine the legality of connections (see [@sec:connects]).
 
-The principal type is used to determine whether two circuit components may be connected.
+The term "principal type" is used to emphasize it is the FIRRTL type ([@sec:types])
+associated with a circuit component.
+The term is meant to distinguish it from the kind of component.
+(i.e., nodes, wires, registers, ports, submodule instances, and memories).
 
-For wires, registers, ports, the principal component is declared after the colon `:` when the circuit component is declared.
+For wires, registers, ports, the principal component is declared after the colon (`:`)
+when the circuit component is declared.
 
-For nodes, the principal type is inferred from the type of the expression on the left hand side of the equals sign `=` when the node is declared.
+For nodes, the principal type is inferred from the type of the expression on the left hand side
+of the equals sign (`=`) when the node is declared.
 
-For submodule instances, TODO: ???
+For submodule instances, the principal type is a bundle type determined by the ports it contains.
+Each `output` port introduces a new field with matching name and type.
+Each `input` port indtroduces a new field with matching name and type, which which is is flipped.
+
+The principal type of memories is a bundle type.
+The details are given in `[@sec:mem]`.
 
 ## Type Equivalence
 

--- a/spec.md
+++ b/spec.md
@@ -593,7 +593,7 @@ The type of the submodule instance `passthrough`{.firrtl} above is thus:
 
 ## Memories
 
-Memories are large stateful elements of a design.
+Memories are stateful elements of a design.
 
 Example:
 
@@ -1196,7 +1196,7 @@ Registers with bundle types are especially common.
 However, when using bundle types in stateful elements, the notion of `flip` is meaningless.
 There is no directionality to the data inside a register; the data just *is*.
 
-A passive type is a which does not make use of `flip`.
+A passive type is a type which does not make use of `flip`.
 More precisely, a passive type is defined recursively:
 
 - All ground types are passive.
@@ -1241,11 +1241,7 @@ Statements declare the circuit components and describe their connectivity.
 
 ## Connects
 
-The components of a module can be connected together using connect statements.
-
-These connections can be both physical, as if the components were connected together with a wire,
-but also logical, allowing metadata such as probes (see [@sec:probe-types;@sec:probe])
-and properties (see [@sec:property-types]) to flow across it during elaboration.
+The components of a module can be connected together using `connect`{.firrtl} statements.
 
 The following example demonstrates connecting a module's input port to its output port, where port `myinput`{.firrtl} is connected to port `myoutput`{.firrtl}.
 

--- a/spec.md
+++ b/spec.md
@@ -3821,7 +3821,9 @@ letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
        | "o" | "p" | "q" | "r" | "s" | "t" | "u"
        | "v" | "w" | "x" | "y" | "z" ;
 
-(* Tokens: Info *)
+(* Fileinfo communicates Chisel source file and line/column info *)
+linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;
+lineinfo = string, " ", linecol ;
 info = "@" , "[" , lineinfo, { ",", lineinfo }, "]" ;
 lineinfo = string, " ", linecol ;
 linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;

--- a/spec.md
+++ b/spec.md
@@ -465,7 +465,7 @@ Any use in place of an integer is disallowed.
 Circuit components are the named objects which may be contained within a module.
 They are: nodes, wires, registers, ports, and submodule instances.
 
-TODO: What about `mem`\s?
+TODO: What about `mem`s?
 
 ## Nodes
 
@@ -481,7 +481,7 @@ Example:
 Nodes are given a name and a definition.
 Unlike wires, they can only be assigned to at the point they are defined.
 (TODO: Do all values need to be in scope above the point of definition?)
-They cannot be connected to and so they do not have last connect semantics [@sec:conditional-last-connect-semantics].
+They cannot be connected (see [@sec:connects]).
 
 ## Wires
 
@@ -512,7 +512,7 @@ The state of a register may be any passive type (see [@sec:passive-types]) and m
 (TODO: is the `const` restriction a consequence of the passive part or not? Why is this required?)
 (TODO: Is this true with probes and stufff?)
 Registers are always associated with a clock.
-Optionally, registers may have a reset signal. (TODO: What about an initial value?)
+Optionally, registers may have a reset signal.
 
 On every cycle, a register will drive its current value and then latch the value it will take on for the next cycle.
 
@@ -573,6 +573,7 @@ The keyword `of` is used instead of the colon `:` since `Passthrough` is not a t
 A submodule may not be connected to.
 However, a module may connect to the ports of a submodule instance.
 The rules for connecting to these ports is mirrored from the rules for how to connect to them when inside the module.
+TODO: Does `inst` require that the thing after the `of` is a FIRRTL `module`? Can it be a `mem` or an `extmodule`?
 
 
 # Types

--- a/spec.md
+++ b/spec.md
@@ -1426,8 +1426,8 @@ invalidate w
 ```
 
 Invalidate statements can be applied to any circuit component of any type.
-However, if the circuit component cannot be connected to, then the statement has no effect on the component.
-This allows the invalidate statement to be applied to any component, to explicitly ignore initialization coverage errors.
+This allows the invalidate statement to be applied to any component,
+to explicitly ignore initialization coverage errors.
 
 The following example demonstrates the effect of invalidating a variety of circuit components with aggregate types.
 See [@sec:the-invalidate-algorithm] for details on the algorithm for determining what is invalidated.

--- a/spec.md
+++ b/spec.md
@@ -477,10 +477,12 @@ Example:
 ```
 
 Nodes are given a name and a definition.
-Unlike wires, they must be assigned to at the point they are defined.
-(TODO: "The value is given as part of the definition and the expression cannot be changed.")
+(TODO: "They cannot be connected (see [@sec:connects])." Yeah, they kinda can, but not in a source position?)
+
+The principal type of a node (see [@sec:principal-types-of-circuit-components])
+is inferred from the type of the expression on the right hand side of the equals sign `=`.
+
 (TODO: Do all values need to be in scope above the point of definition?)
-They cannot be connected (see [@sec:connects]).
 
 ## Wires
 
@@ -499,7 +501,7 @@ Example:
 
 ## Registers
 
-Registers are the stateful elements of a design.
+Registers are small stateful elements of a design.
 
 Registers can be connected (see [@sec:connects]).
 The state of the register is controlled through what is connected to it.
@@ -533,8 +535,9 @@ wire myinit: SInt
 regreset myreg: SInt, myclock, myreset, myinit
 ```
 
-Semantically, the next value is latched on the positive edge of the clock.
-Additionally, a register's initial value is indeterminate (see [@sec:indeterminate-values]).
+Semantically, registers become flip-flops in the design.
+The the next value is latched on the positive edge of the clock.
+For registers without a reset, the initial value is indeterminate (see [@sec:indeterminate-values]).
 
 
 ## Ports
@@ -555,7 +558,7 @@ The two keywords only differ in the rules for how they may be connected (see [@s
 
 A module in FIRRTL is allowed to contain submodules.
 Each submodule instance must be given a name.
-It must also name the FIRRTL module it is instantiating.
+It must also name the FIRRTL module or external module it is instantiating.
 
 Example:
 

--- a/spec.md
+++ b/spec.md
@@ -470,8 +470,8 @@ Any use in place of an integer is disallowed.
 
 Circuit components are the named parts of a module corresponding to physical hardware.
 
-There are six **kinds** of circuit components.
-They are: nodes, wires, registers, ports, submodule instances, and memories.
+There are seven **kinds** of circuit components.
+They are: nodes, wires, registers, output ports, input ports, submodule instances, and memories.
 
 We use connections to wire circuit components together in the hardware (see [@sec:connects]).
 
@@ -564,7 +564,7 @@ The the next value is latched on the positive edge of the clock.
 For registers without a reset, the initial value is indeterminate (see [@sec:indeterminate-values]).
 
 
-## Ports
+## Output Ports and Input Ports
 
 The way a module interacts with the outside world is through its ports.
 

--- a/spec.md
+++ b/spec.md
@@ -480,7 +480,7 @@ Nodes are named expressions in FIRRTL.
 Example:
 
 ```firrtl
-    node mynode = and(in, UInt<4>(1))
+node mynode = and(in, UInt<4>(1))
 ```
 
 The type of a node is the type of the expression given in the definition.
@@ -493,9 +493,9 @@ Wires represent named expressions whose value is determined by FIRRTL `connect`{
 Example:
 
 ``` firrtl
-    wire mywire: UInt<1>
+wire mywire: UInt<1>
 
-    connect mywire, UInt<1>(0)
+connect mywire, UInt<1>(0)
 ```
 
 Unlike nodes, the type of a wire must be explicitly declared.
@@ -551,8 +551,8 @@ The way a module interacts with the outside world is through its ports.
 Example:
 
 ``` firrtl
-  input myinput : UInt<1>
-  output myinput : SInt<8>
+input myinput : UInt<1>
+output myinput : SInt<8>
 ```
 
 For both variants of port, the type is given after the colon (`:`{.firrtl}).

--- a/spec.md
+++ b/spec.md
@@ -460,6 +460,57 @@ The following string-encoded integer literals all have the value `-42`:
 Radix-specified integer literals are only usable when constructing hardware integer literals.
 Any use in place of an integer is disallowed.
 
+# Circuit Components
+
+Circuit components are the named objects which may be contained within a module.
+They are: nodes, wires, registers, submodule instances, and ports.
+
+## Nodes
+
+Nodes are named expressions in FIRRTL.
+They represent a small piece of combinational logic.
+
+Example:
+
+```firrtl
+    node mynode = and(in, UInt<4>(1))
+```
+
+Nodes are given a name and a definition.
+Unlike wires, they can only be assigned to at the point they are defined.
+(TODO: Do all values need to be in scope above the point of definition?)
+They cannot be connected to and so they do not have last connect semantics [@sec:conditional-last-connect-semantics].
+
+## Wires
+
+A wire is a named combinational circuit component that can be connected to and from using connect statements.
+
+Wires represent named expressions whose value is determined by FIRRTL `connect`{.firrtl} statements (see [@sec:connects]).
+Unlike nodes, last connect semantics [@sec:conditional-last-connect-semantics] apply to wires.
+Also unlike nodes, the type of a wire must be explicitly declared, since it cannot be inferred from the value of the definition.
+
+TODO: Circular definitions? c.f. with nodes.
+
+Example:
+
+``` firrtl
+    wire mywire: UInt<1>
+
+    connect mywire, UInt<1>(0)
+```
+
+## Registers
+
+TODO
+
+## Submodule Instances
+
+TODO
+
+## Ports
+
+TODO
+
 # Types
 
 FIRRTL has four classes of types: _ground_ types, _aggregate_ types, _reference_ types, and _property_ types.
@@ -1203,13 +1254,7 @@ See [@sec:conditionals] for details on the conditional statement.
 
 ## Wires
 
-A wire is a named combinational circuit component that can be connected to and from using connect statements.
-
-The following example demonstrates instantiating a wire with the given name `mywire`{.firrtl} and type `UInt`{.firrtl}.
-
-``` firrtl
-wire mywire: UInt
-```
+TODO: Moved to circuit components
 
 ## Registers
 

--- a/spec.md
+++ b/spec.md
@@ -479,16 +479,14 @@ Example:
 ```
 
 Nodes are given a name and a definition.
-Unlike wires, they can only be assigned to at the point they are defined.
+Unlike wires, they must be assigned to at the point they are defined.
+(TODO: "The value is given as part of the definition and the expression cannot be changed.")
 (TODO: Do all values need to be in scope above the point of definition?)
 They cannot be connected (see [@sec:connects]).
 
 ## Wires
 
-A wire is a named combinational circuit component that can be connected to and from using connect statements.
-
 Wires represent named expressions whose value is determined by FIRRTL `connect`{.firrtl} statements (see [@sec:connects]).
-Unlike nodes, last connect semantics [@sec:conditional-last-connect-semantics] apply to wires.
 Also unlike nodes, the type of a wire must be explicitly declared, since it cannot be inferred from the value of the definition.
 
 TODO: Circular definitions? c.f. with nodes.
@@ -510,7 +508,7 @@ The state of the register is controlled through what is connected to it.
 
 The state of a register may be any passive type (see [@sec:passive-types]) and may not be `const`{.firrtl}.
 (TODO: is the `const` restriction a consequence of the passive part or not? Why is this required?)
-(TODO: Is this true with probes and stufff?)
+(TODO: Is this true with probes and stuff?)
 Registers are always associated with a clock.
 Optionally, registers may have a reset signal.
 
@@ -1120,8 +1118,7 @@ does not imply a literal value at a point in the emitted design.  Constant types
 may be used in ports, wire, and nodes.  Operations on constant type are well defined.
 With any exception listed in the definition for such operations as have exceptions,
 an operation whose arguments are constant produces a constant.  An operation
-with some non-constant arguments produce a non-constant.  Constants can be used
-in any context with a source flow which allows a non-constant.  Constants may be
+with some non-constant arguments produce a non-constant.  Constants may be
 used as the target of a connect so long as the source of the connect is itself
 constant.  These rules ensure all constants are derived from constant integer
 expressions or from constant-typed input ports of a public module.
@@ -1163,6 +1160,19 @@ Vector types are passive if their element type is passive.
 And bundle types are passive if no fields are flipped and if all field types are passive.
 
 All property types are passive.
+
+## Principal Types of Circuit Components
+
+Each circuit component in a module is associated to a type called its principal type.
+This is the type of data that flows through the component.
+
+The principal type is used to determine whether two circuit components may be connected.
+
+For wires, registers, ports, the principal component is declared after the colon `:` when the circuit component is declared.
+
+For nodes, the principal type is inferred from the type of the expression on the left hand side of the equals sign `=` when the node is declared.
+
+For submodule instances, TODO: ???
 
 ## Type Equivalence
 

--- a/spec.md
+++ b/spec.md
@@ -1252,8 +1252,9 @@ Statements declare the circuit components and describe their connectivity.
 
 ## Connects
 
-Circuit components can be connected together.
-This connection can be both physical, as if the components were connected together with a wire,
+The components of a module can be connected together using connect statements.
+
+These connections can be both physical, as if the components were connected together with a wire,
 but also logical, allowing metadata such as probes (see [@sec:probe-types;@sec:probe])
 and properties (see [@sec:property-types]) to flow across it during elaboration.
 

--- a/spec.md
+++ b/spec.md
@@ -1189,11 +1189,11 @@ A passive type is a which does not make use of `flip`.
 More precisely, a passive type is defined recursively:
 
 * All ground types are passive.
-* Probe types are passive.
-* Properties types are passive.
+* All probe types are passive.
+* All properties types are passive.
 * A vector type is passive if and only if the element type is passive.
 * A bundle type is passive if and only if it contains no field which is marked `flip` and the type of each field is passive.
-* An enum is passive if and only if the type of each of its variants is passive.
+* An enum type is passive if and only if the type of each of its variants is passive.
 
 Registers and memories may only be parametrized over passive types.
 

--- a/spec.md
+++ b/spec.md
@@ -469,6 +469,7 @@ Any use in place of an integer is disallowed.
 # Circuit Components
 
 Circuit components are the named objects which may be contained within a module.
+
 There are six kinds of circuit components.
 They are: nodes, wires, registers, ports, submodule instances, and memories.
 

--- a/spec.md
+++ b/spec.md
@@ -482,20 +482,19 @@ Example:
     node mynode = and(in, UInt<4>(1))
 ```
 
-Nodes are given a name and a definition.
-(TODO: "They cannot be connected (see [@sec:connects])." Yeah, they kinda can, but not in a source position?)
-
+The value of a node is determined by the expression given in the definition.
 The principal type of a node (see [@sec:principal-types-of-circuit-components])
-is inferred from the type of the expression on the right hand side of the equals sign `=`.
+is the inferred type of this expression.
 
-(TODO: Do all values need to be in scope above the point of definition?)
+The defining expression may reference circuit components defines *above* the declaration of the node itself.
+It may not reference the node being define.
+Similarly, it may not reference circuit components defined after it.
+
 
 ## Wires
 
 Wires represent named expressions whose value is determined by FIRRTL `connect`{.firrtl} statements (see [@sec:connects]).
 Also unlike nodes, the type of a wire must be explicitly declared, since it cannot be inferred from the value of the definition.
-
-TODO: Circular definitions? c.f. with nodes.
 
 Example:
 
@@ -512,9 +511,7 @@ Registers are small stateful elements of a design.
 Registers can be connected (see [@sec:connects]).
 The state of the register is controlled through what is connected to it.
 
-The state of a register may be any passive type (see [@sec:passive-types]) and may not be `const`{.firrtl}.
-(TODO: is the `const` restriction a consequence of the passive part or not? Why is this required?)
-(TODO: Is this true with probes and stuff?)
+The state of a register may be any non-`const`{.firrtl} passive type (see [@sec:passive-types]).
 Registers are always associated with a clock.
 Optionally, registers may have a reset signal.
 


### PR DESCRIPTION
As of version 3.2.0, the FIRRTL Spec makes several references to a notion called a "circuit component", including in the introductory chapter.
This latent concept seems to capture the important notion we informally refer to at the Chisel level as "hardware".
I'm adding a section early on to properly define this concept and to raise salience of this important notion of FIRRTL.

The sections these references appear are given with the numbers above each section:

2.1
Chisel designers manipulate circuit components using Scala functions, encode their interfaces in Scala types, and use Scala’s object-orientation features to write their own circuit libraries.

7.2.2
In a connection between circuit components with bundle types, the data carried by the flipped fields flow in the opposite direction as the data carried by the non-flipped fields.

7.3
For use in cross-module references (hierarchical references in Verilog), a reference to a probe of the circuit component is used. See Section 8.14 for details.

7.7
It is inappropriate for some circuit components to be declared with a type that allows for data to flow in both directions. For example, all sub-elements in a memory should flow in the same direction. These components are restricted to only have a passive type.

8.1
The connect statement is used to specify a physically wired connection between two circuit components.

8.1
Connect statements from a narrower ground type component to a wider ground type component will have its value automatically sign-extended or zero-extended to the larger bit width. The behavior of connect statements between two circuit components with aggregate types is defined by the connection algorithm in Section 8.1.1.

8.1.2
When a connection to a sub-element of an aggregate component is followed by a connection to the entire circuit component, the later connection overwrites the earlier sub-element connection.

8.3
A wire is a named combinational circuit component that can be connected to and from using connect statements.

8.4
A register is a named stateful circuit component. Reads from a register return the current value of the element, writes are not visible until after a positive edges of the register’s clock port.

8.5
An invalidate statement is used to indicate that a circuit component contains indeterminate values (see Section 16.1). It is specified as follows: 

```
wire w: UInt 
invalidate w 
```

Invalidate statements can be applied to any circuit component of any type. However, if the circuit component cannot be connected to, then the statement has no effect on the component. This allows the invalidate statement to be applied to any component, to explicitly ignore initialization coverage errors. The following example demonstrates the effect of invalidating a variety of circuit components with aggregate types. See Section 8.5.1 for details on the algorithm for determining what is invalidated.

8.5
The following example demonstrates the effect of invalidating a variety of circuit components with aggregate types. See Section 8.5.1 for details on the algorithm for determining what is invalidated.

8.5.5
The conditional statement creates a new scope within each of its when and else branches. It is an error to refer to any component declared within a branch after the branch has ended. As mention in Section 14, circuit component declarations in a module must be unique within the module’s flat namespace; this means that shadowing a component in an enclosing scope with a component of the same name inside a conditional statement is not allowed.

8.8.6
In the case where a connection to a circuit component is followed by a conditional statement containing a connection to the same component, the connection is overwritten only when the condition holds. Intuitively, a multiplexer is generated such that when the condition is low, the multiplexer returns the old value, and otherwise returns the new value. For details about the multiplexer, see Section 9.8.

8.8.6
The behavior of conditional connections to circuit components with aggregate types can be modeled by first expanding each connect into individual connect statements on its ground elements (see Section 8.1.1 for the connection algorithm) and then applying the conditional last connect semantics.

9
FIRRTL expressions are used for creating constant integers, for creating literal property type expressions, for referring to a declared circuit component, for statically and dynamically accessing a nested element within a component, for creating multiplexers, for performing primitive operations, and for reading a remote reference to a probe.

9.4
A reference is simply a name that refers to a previously declared circuit component. It may refer to a module port, node, wire, register, instance, or memory.

11
The flow of a reference to a declared circuit component depends on the kind of circuit component. A reference to an input port, an instance, a memory, and a node, is a source. A reference to an output port is a sink. A reference to a wire or register is duplex.

12
For all circuit components declared with unspecified widths, the FIRRTL compiler will infer the minimum possible width that maintains the legality of all its incoming connections. If a component has no incoming connections, and the width is unspecified, then an error is thrown to indicate that the width could not be inferred.

14
Each module has an identifier namespace containing the names of all port and circuit component declarations. Thus, all declarations within a module must have unique names.
