### PR TITLE
[patch] Reorganize section on Connections

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1162,6 +1162,29 @@ Consequently, `{a:UInt, b:UInt}`{.firrtl} is not equivalent to `{b:UInt, a:UInt}
 
 Two property types are equivalent if they are the same concrete property type.
 
+# Connections
+
+## Flow
+
+An expression's flow partially determines the legality of connecting to and from the expression.
+Every expression is classified as either *source*, *sink*, or *duplex*.
+For details on connection rules refer back to [@sec:connects].
+
+The flow of a reference to a declared circuit component depends on the kind of circuit component.
+A reference to an input port, an instance, a memory, and a node, is a source.
+A reference to an output port is a sink. A reference to a wire or register is duplex.
+
+The flow of a sub-index or sub-access expression is the flow of the vector-typed expression it indexes or accesses.
+
+The flow of a sub-field expression depends upon the orientation of the field.
+If the field is not flipped, its flow is the same flow as the bundle-typed expression it selects its field from.
+If the field is flipped, then its flow is the reverse of the flow of the bundle-typed expression it selects its field from.
+The reverse of source is sink, and vice-versa.
+The reverse of duplex remains duplex.
+
+The flow of all other expressions are source.
+
+
 # Statements
 
 A module body consists of a sequence of statements.
@@ -2730,26 +2753,6 @@ module MyModule :
 The probed expression must be a static reference.
 
 See [@sec:probe-types;@sec:probe] for more details on probe references and their use.
-
-# Flows
-
-An expression's flow partially determines the legality of connecting to and from the expression.
-Every expression is classified as either *source*, *sink*, or *duplex*.
-For details on connection rules refer back to [@sec:connects].
-
-The flow of a reference to a declared circuit component depends on the kind of circuit component.
-A reference to an input port, an instance, a memory, and a node, is a source.
-A reference to an output port is a sink. A reference to a wire or register is duplex.
-
-The flow of a sub-index or sub-access expression is the flow of the vector-typed expression it indexes or accesses.
-
-The flow of a sub-field expression depends upon the orientation of the field.
-If the field is not flipped, its flow is the same flow as the bundle-typed expression it selects its field from.
-If the field is flipped, then its flow is the reverse of the flow of the bundle-typed expression it selects its field from.
-The reverse of source is sink, and vice-versa.
-The reverse of duplex remains duplex.
-
-The flow of all other expressions are source.
 
 # Width Inference
 

--- a/spec.md
+++ b/spec.md
@@ -1168,13 +1168,12 @@ Two property types are equivalent if they are the same concrete property type.
 
 The direction that signals travel across wires is determined by multiple factors: the kind of circuit component (e.g., `input` vs `output`), the side of a connect statement it appears on, and the presence of `flip`s if the signal is a bundle type.
 
-To ensure connections are meaningful when taking directionality into account, every expression in FIRRTL has a flow, in addition to its type.
+To ensure connections are meaningful when taking directionality into account, every expression in FIRRTL has a **flow**.
+The flow of an expression can be one of **source**, **sink**, or **duplex**.
 
-The flow of an expression can be one of *source*, *sink*, or *duplex*.
-
-A source expression supplies a signal, and can be used to drive a circuit component.
+A source expression supplies a signal and can be used to drive a circuit component.
 A sink expression can be driven by another expression.
-A duplex expression is simply an expression that is both a source and sink.
+A duplex expression is an expression that is both a source and sink.
 
 The rules for the flow of an expression are as follows:
 

--- a/spec.md
+++ b/spec.md
@@ -1193,12 +1193,7 @@ Ports are always considered from the perspective of "inside the module".
 Moreover, input ports may only appear "on the left side" of a connect, while output ports may only appear "on the right side" of a connect.
 Finally, while submodules instances and memories are strictly sources, they interact with the sub-field rule below, allowing connections to their input ports
 
-# Statements
-
-A module body consists of a sequence of statements.
-Statements declare the circuit components and describe their connectivity.
-
-## Connects
+## The Connect Statement
 
 The components of a module can be connected together using `connect`{.firrtl} statements.
 
@@ -1301,6 +1296,11 @@ module MyModule :
 ```
 
 See [@sec:sub-fields] for more details about sub-field expressions.
+
+# Statements
+
+A module body consists of a sequence of statements.
+Statements declare the circuit components and describe their connectivity.
 
 ## Empty
 

--- a/spec.md
+++ b/spec.md
@@ -1166,24 +1166,32 @@ Two property types are equivalent if they are the same concrete property type.
 
 ## Flow
 
-An expression's flow partially determines the legality of connecting to and from the expression.
-Every expression is classified as either *source*, *sink*, or *duplex*.
-For details on connection rules refer back to [@sec:connects].
+The direction that signals travel across wires is determined by multiple factors: the kind of circuit component (e.g., `input` vs `output`), the side of a connect statement it appears on, and the presence of `flip`s if the signal is a bundle type.
 
-The flow of a reference to a declared circuit component depends on the kind of circuit component.
-A reference to an input port, an instance, a memory, and a node, is a source.
-A reference to an output port is a sink. A reference to a wire or register is duplex.
+To ensure connections are meaningful when taking directionality into account, every expression in FIRRTL has a flow, in addition to its type.
 
-The flow of a sub-index or sub-access expression is the flow of the vector-typed expression it indexes or accesses.
+The flow of an expression can be one of *source*, *sink*, or *duplex*.
 
-The flow of a sub-field expression depends upon the orientation of the field.
-If the field is not flipped, its flow is the same flow as the bundle-typed expression it selects its field from.
-If the field is flipped, then its flow is the reverse of the flow of the bundle-typed expression it selects its field from.
-The reverse of source is sink, and vice-versa.
-The reverse of duplex remains duplex.
+A source expression supplies a signal, and can be used to drive a circuit component.
+A sink expression can be driven by another expression.
+A duplex expression is simply an expression that is both a source and sink.
 
-The flow of all other expressions are source.
+The rules for the flow of an expression are as follows:
 
+If the expression is a reference, we look at the kind of the circuit component:
+
+- Nodes are sources.
+- Wires and registers are duplex.
+- For ports, `input` ports are sources and `output` ports are sinks.
+- Submodule instances are sources.
+- Memories are sources.
+
+Here are a few comments to help with intuition:
+Nodes may only appear "on the left side" of a connect.
+Wires and registers may appear "on either side of a connect statement".
+Ports are always considered from the perspective of "inside the module".
+Moreover, input ports may only appear "on the left side" of a connect, while output ports may only appear "on the right side" of a connect.
+Finally, while submodules instances and memories are strictly sources, they interact with the sub-field rule below, allowing connections to their input ports
 
 # Statements
 


### PR DESCRIPTION
The section Connects is in need of reorganization.

The Connect section has been lifted out of the Statements section (which I'm aiming to remove eventually in a future PR) and renamed to Connections.

The section on Flows has been moved under Connections and placed at the start (since the connection rules are defined in terms of Flow). The rules for Flow have been elaborated. Some motivation has been given. I avoid leaning on the phraseology, "all other expressions" in favor of naming the remaining classes of expressions explicitly.

I might not touch it in this PR, but I would like to keep my eye on the Last Connect Semantics section. It is now the only section which isn't related to the legality of connects, and it has interactions with conditionals. This suggests that it will probably be moved at some point in the future.