### PR TITLE
[patch] Refactor Grammar

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4075,16 +4075,18 @@ conditional_when = "when" , expr , ":" [ info ] , newline ,
     indent , statement, { statement } , dedent ,
     [ "else" , ":" , indent , statement, { statement } , dedent ] ;
 
-conditional_when = "match" , expr , ":" , [ info ] , newline ,
+conditional_match = "match" , expr , ":" , [ info ] , newline ,
     [ indent ,
-      { id , [ "(" , id , ")" ] , ":" , newline ,
-        [ indent , { statement } , dedent ]
-      } ,
+        { conditional_match_branch } ,
       dedent ] ;
+
+conditional_match_branch =
+  id , [ "(" , id , ")" ] , ":" , newline ,
+    [ indent , { statement } , dedent ]
 
 (* Commands *)
 command =
-  "stop" , "(" , expr , "," , expr , "," , int , ")" , [ info ]
+    "stop" , "(" , expr , "," , expr , "," , int , ")" , [ info ]
   | "force" , "(" , expr , "," , expr , "," , ref_expr , "," , expr , ")"
   | "force_initial" , "(" , ref_expr , "," , expr , ")"
   | "release" , "(" , expr , "," , expr , "," , ref_expr , ")"

--- a/spec.md
+++ b/spec.md
@@ -4047,34 +4047,39 @@ group =
 skip = "skip" , [ info ] ;
 
 (* References *)
+reference =
+    static_reference
+  | dynamic_reference
+
 static_reference =
     id
   | static_reference , "." , id
   | static_reference , "[" , int , "]" ;
 
-reference = static_reference
-          | reference , "[" , expr , "]" ;
+dynamic_reference =
+    reference , "[" , expr , "]" ;
 
 (* Expressions *)
 expr =
-    reference
+    expr_reference
   | expr_lit
   | expr_enum
   | expr_mux
   | expr_read
   | expr_primop ;
 
+expr_reference = reference
 expr_lit = ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | rint ) , ")" ;
 expr_enum = type_enum , "(" , id , [ "," , expr ] , ")" ;
 expr_mux = "mux" , "(" , expr , "," , expr , "," , expr , ")" ;
 expr_read = "read" , "(" , expr_probe , ")" ;
 
-expr_probe = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
-           | static_reference ;
+expr_probe =
+    ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
+  | static_reference ;
 
 property_literal_expr = "Integer", "(", int, ")" ;
 property_expr = static_reference | property_literal_expr ;
-
 expr_primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
 
 (* Types *)

--- a/spec.md
+++ b/spec.md
@@ -4003,7 +4003,7 @@ expr =
   | expr_primop ;
 
 expr_lit = ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | rint ) , ")" ;
-expr_enum = type_enum , "(" , id , [ "," , expr ] , ")"
+expr_enum = type_enum , "(" , id , [ "," , expr ] , ")" ;
 expr_mux = "mux" , "(" , expr , "," , expr , "," , expr , ")" ;
 expr_read = "read" , "(" , ref_expr , ")" ;
 
@@ -4062,7 +4062,7 @@ read_under_write =  "old" | "new" | "undefined" ;
 connectlike =
     "connect" , reference , "," , expr , [ info ]
   | "invalidate" , reference , [ info ]
-  | "attach(" , reference , { "," ,  reference } , ")" , [ info ]
+  | "attach" , "(" , reference , { "," ,  reference } , ")" , [ info ]
   | "define" , static_reference , "=" , ref_expr , [ info ]
   | "propassign" , static_reference , "," , property_expr , [ info ] ;
 

--- a/spec.md
+++ b/spec.md
@@ -3952,9 +3952,9 @@ lineinfo = string, " ", linecol ;
 info = "@" , "[" , lineinfo, { ",", lineinfo }, "]" ;
 
 (* Type definitions *)
-type = ( [ "const" ] , type_constable ) | type_probe ;
+type = ( [ "const" ] , type_hardware ) | type_probe ;
 
-type_constable =
+type_hardware =
     type_ground
   | type_bundle
   | type_vec

--- a/spec.md
+++ b/spec.md
@@ -4096,12 +4096,11 @@ group = "group" , id , "of" , id , ":" , [ info ] , newline ,
 skip = "skip" , [ info ] ;
 
 (* Module definitions *)
-port = ( "input" | "output" ) , id , ":" , (type | type_property) , [ info ] ;
 module = "module" , id , ":" , [ info ] , newline , indent ,
            { port , newline } ,
            { statement , newline } ,
          dedent ;
-type_param = int | string_dq | string_sq ;
+
 extmodule = "extmodule" , id , ":" , [ info ] , newline , indent ,
               { port , newline } ,
               [ "defname" , "=" , id , newline ] ,
@@ -4109,11 +4108,15 @@ extmodule = "extmodule" , id , ":" , [ info ] , newline , indent ,
               { "ref" , static_reference , "is" ,
                 '"' , static_reference , '"' , newline } ,
             dedent ;
+
 intmodule = "intmodule" , id , ":" , [ info ] , newline , indent ,
               { port , newline } ,
               "intrinsic" , "=" , id , newline ,
               { "parameter" , "=" , ( int | string_dq ) , newline } ,
             dedent ;
+
+port = ( "input" | "output" ) , id , ":" , (type | type_property) , [ info ] ;
+type_param = int | string_dq | string_sq ;
 
 (* Group definitions *)
 declgroup =
@@ -4129,11 +4132,20 @@ sem_ver = int , "."  , int , "." , int ;
 version = "FIRRTL" , "version" , sem_ver ;
 
 (* Circuit definition *)
+top_level_decl =
+      module
+    | extmodule
+    | intmodule
+    | declgroup
+    | type_alias_decl ;
+
 circuit =
   version , newline ,
   "circuit" , id , ":" , [ annotations ] , [ info ] , newline , indent ,
-    { module | extmodule | intmodule | declgroup | type_alias_decl } ,
+    { top_level_decl } ,
   dedent ;
+
+
 ```
 
 # Versioning Scheme of this Document

--- a/spec.md
+++ b/spec.md
@@ -4030,9 +4030,9 @@ expr =
 expr_lit = ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | rint ) , ")" ;
 expr_enum = type_enum , "(" , id , [ "," , expr ] , ")" ;
 expr_mux = "mux" , "(" , expr , "," , expr , "," , expr , ")" ;
-expr_read = "read" , "(" , ref_expr , ")" ;
+expr_read = "read" , "(" , expr_probe , ")" ;
 
-ref_expr = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
+expr_probe = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
            | static_reference ;
 
 static_reference = id
@@ -4088,7 +4088,7 @@ connectlike =
     "connect" , reference , "," , expr , [ info ]
   | "invalidate" , reference , [ info ]
   | "attach" , "(" , reference , { "," ,  reference } , ")" , [ info ]
-  | "define" , static_reference , "=" , ref_expr , [ info ]
+  | "define" , static_reference , "=" , expr_probe , [ info ]
   | "propassign" , static_reference , "," , property_expr , [ info ] ;
 
 (* Conditionals *)
@@ -4112,10 +4112,10 @@ conditional_match_branch =
 (* Commands *)
 command =
     "stop" , "(" , expr , "," , expr , "," , int , ")" , [ info ]
-  | "force" , "(" , expr , "," , expr , "," , ref_expr , "," , expr , ")"
-  | "force_initial" , "(" , ref_expr , "," , expr , ")"
-  | "release" , "(" , expr , "," , expr , "," , ref_expr , ")"
-  | "release_initial" , "(" , ref_expr , ")"
+  | "force" , "(" , expr , "," , expr , "," , expr_probe , "," , expr , ")"
+  | "force_initial" , "(" , expr_probe , "," , expr , ")"
+  | "release" , "(" , expr , "," , expr , "," , expr_probe , ")"
+  | "release_initial" , "(" , expr_probe , ")"
   | "printf" , "(" ,
         expr , "," ,
         expr , "," ,

--- a/spec.md
+++ b/spec.md
@@ -4074,7 +4074,8 @@ expr_mux = "mux" , "(" , expr , "," , expr , "," , expr , ")" ;
 expr_read = "read" , "(" , expr_probe , ")" ;
 
 expr_probe =
-    ( "probe" | "rwprobe" ) , "(" , reference_static , ")"
+  "probe" , "(" , reference_static , ")"
+  "rwprobe" , "(" , reference_static , ")"
   | reference_static ;
 
 property_literal_expr = "Integer", "(", int, ")" ;

--- a/spec.md
+++ b/spec.md
@@ -4010,13 +4010,6 @@ ref_expr = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
 property_literal_expr = "Integer", "(", int, ")" ;
 property_expr = static_reference | property_literal_expr ;
 
-(* Force and Release *)
-force_release =
-    "force_initial" , "(" , ref_expr , "," , expr , ")"
-  | "release_initial" , "(" , ref_expr , ")"
-  | "force" , "(" , expr , "," , expr , "," , ref_expr , "," , expr , ")"
-  | "release" , "(" , expr , "," , expr , "," , ref_expr , ")" ;
-
 (* Statements *)
 statement =
     circuit_component
@@ -4081,10 +4074,12 @@ conditional_when = "match" , expr , ":" , [ info ] , newline ,
 
 (* Commands *)
 command =
-  | "printf(" , expr , "," , expr , "," , string_dq ,
-    { "," , expr } , ")" , [ ":" , id ] , [ info ]
-  | force_release , [ info ]
+  | "printf(" , expr , "," , expr , "," , string_dq , { "," , expr } , ")" , [ ":" , id ] , [ info ]
   | "stop(" , expr , "," , expr , "," , int , ")" , [ info ] ;
+  | "force" , "(" , expr , "," , expr , "," , ref_expr , "," , expr , ")"
+  | "force_initial" , "(" , ref_expr , "," , expr , ")"
+  | "release" , "(" , expr , "," , expr , "," , ref_expr , ")" ;
+  | "release_initial" , "(" , ref_expr , ")"
 
 (* Groups *)
 group = "group" , id , "of" , id , ":" , [ info ] , newline ,

--- a/spec.md
+++ b/spec.md
@@ -4066,7 +4066,7 @@ statement =
 
 (* Module definitions *)
 port = ( "input" | "output" ) , id , ":" , (type | type_property) , [ info ] ;
-module = [ "public" ] , "module" , id , ":" , [ info ] , newline , indent ,
+module = "module" , id , ":" , [ info ] , newline , indent ,
            { port , newline } ,
            { statement , newline } ,
          dedent ;
@@ -4100,7 +4100,7 @@ version = "FIRRTL" , "version" , sem_ver ;
 (* Circuit definition *)
 circuit =
   version , newline ,
-  "circuit" , ":" , [ annotations ] , [ info ] , newline , indent ,
+  "circuit" , id , ":" , [ annotations ] , [ info ] , newline , indent ,
     { module | extmodule | intmodule | declgroup | type_alias_decl } ,
   dedent ;
 ```

--- a/spec.md
+++ b/spec.md
@@ -3911,24 +3911,24 @@ said to have "internal" convention.
 circuit =
   version , newline ,
   "circuit" , id , ":" , [ annotations ] , [ info ] , newline , indent ,
-    { top_level_decl } ,
+    { decl } ,
   dedent ;
 
 (* Top-level Declarations *)
-top_level_decl =
-    module
-  | extmodule
-  | intmodule
-  | declgroup
-  | type_alias_decl ;
+decl =
+    decl_module
+  | decl_extmodule
+  | decl_intmodule
+  | decl_group
+  | decl_type_alias ;
 
-module =
+decl_module =
   "module" , id , ":" , [ info ] , newline , indent ,
     { port , newline } ,
     { statement , newline } ,
   dedent ;
 
-extmodule =
+decl_extmodule =
   "extmodule" , id , ":" , [ info ] , newline , indent ,
     { port , newline } ,
     [ "defname" , "=" , id , newline ] ,
@@ -3937,19 +3937,19 @@ extmodule =
       '"' , static_reference , '"' , newline } ,
   dedent ;
 
-intmodule =
+decl_intmodule =
   "intmodule" , id , ":" , [ info ] , newline , indent ,
     { port , newline } ,
     "intrinsic" , "=" , id , newline ,
     { "parameter" , "=" , ( int | string_dq ) , newline } ,
   dedent ;
 
-declgroup =
+decl_group =
   "declgroup" , id , string , ":" , [ info ] , newline , indent ,
     { declgroup , newline } ,
   dedent ;
 
-type_alias_decl = "type", id, "=", type ;
+decl_type_alias = "type", id, "=", type ;
 
 port = ( "input" | "output" ) , id , ":" , (type | type_property) , [ info ] ;
 type_param = int | string_dq | string_sq ;

--- a/spec.md
+++ b/spec.md
@@ -3933,8 +3933,8 @@ decl_extmodule =
     { port , newline } ,
     [ "defname" , "=" , id , newline ] ,
     { "parameter" , id , "=" , type_param , newline } ,
-    { "ref" , static_reference , "is" ,
-      '"' , static_reference , '"' , newline } ,
+    { "ref" , reference_static , "is" ,
+      '"' , reference_static , '"' , newline } ,
   dedent ;
 
 decl_intmodule =
@@ -3999,8 +3999,8 @@ connectlike =
     "connect" , reference , "," , expr , [ info ]
   | "invalidate" , reference , [ info ]
   | "attach" , "(" , reference , { "," ,  reference } , ")" , [ info ]
-  | "define" , static_reference , "=" , expr_probe , [ info ]
-  | "propassign" , static_reference , "," , property_expr , [ info ] ;
+  | "define" , reference_static , "=" , expr_probe , [ info ]
+  | "propassign" , reference_static , "," , property_expr , [ info ] ;
 
 (* Conditional Statements *)
 conditional =
@@ -4047,15 +4047,15 @@ skip = "skip" , [ info ] ;
 
 (* References *)
 reference =
-    static_reference
-  | dynamic_reference
+    reference_static
+  | reference_dynamic
 
-static_reference =
+reference_static =
     id
-  | static_reference , "." , id
-  | static_reference , "[" , int , "]" ;
+  | reference_static , "." , id
+  | reference_static , "[" , int , "]" ;
 
-dynamic_reference =
+reference_dynamic =
     reference , "[" , expr , "]" ;
 
 (* Expressions *)
@@ -4074,11 +4074,11 @@ expr_mux = "mux" , "(" , expr , "," , expr , "," , expr , ")" ;
 expr_read = "read" , "(" , expr_probe , ")" ;
 
 expr_probe =
-    ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
-  | static_reference ;
+    ( "probe" | "rwprobe" ) , "(" , reference_static , ")"
+  | reference_static ;
 
 property_literal_expr = "Integer", "(", int, ")" ;
-property_expr = static_reference | property_literal_expr ;
+property_expr = reference_static | property_literal_expr ;
 expr_primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
 
 (* Types *)

--- a/spec.md
+++ b/spec.md
@@ -3964,7 +3964,6 @@ statement =
   | group
   | skip ;
 
-
 (* Circuit Components *)
 circuit_component =
     circuit_component_node

--- a/spec.md
+++ b/spec.md
@@ -4042,17 +4042,18 @@ conditional_reg =
     "reg" , id , ":" , type , expr , [ info ]
   | "regreset" , id , ":" , type , "," , expr , "," , expr , "," , expr , [info] ;
 
-ruw =  "old" | "new" | "undefined" ;
 circuit_component_mem = "mem" , id , ":" , [ info ] , newline , indent ,
            "data-type" , "=>" , type , newline ,
            "depth" , "=>" , int , newline ,
            "read-latency" , "=>" , int , newline ,
            "write-latency" , "=>" , int , newline ,
-           "read-under-write" , "=>" , ruw , newline ,
+           "read-under-write" , "=>" , read_under_write , newline ,
            { "reader" , "=>" , id , newline } ,
            { "writer" , "=>" , id , newline } ,
            { "readwriter" , "=>" , id , newline } ,
          dedent ;
+
+read_under_write =  "old" | "new" | "undefined" ;
 
 (* Connect-like Statements *)
 connectlike =

--- a/spec.md
+++ b/spec.md
@@ -3990,9 +3990,6 @@ type_enum_alt = id, [ ":" , type_constable ] ;
 (* Probe Types *)
 type_probe = ( "Probe" | "RWProbe" ) , "<", type , [ "," , id , "," ] ">" ;
 
-(* Type alias declaration *)
-type_alias_decl = "type", id, "=", type ;
-
 (* Primitive operations *)
 expr_primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
 
@@ -4163,6 +4160,9 @@ declgroup =
   "declgroup" , id , string , ":" , [ info ] , newline , indent ,
     { declgroup , newline } ,
   dedent ;
+
+(* Type alias declaration *)
+type_alias_decl = "type", id, "=", type ;
 
 (* In-line Annotations *)
 annotations = "%" , "[" , json_array , "]" ;

--- a/spec.md
+++ b/spec.md
@@ -3969,6 +3969,8 @@ type = ( [ "const" ] , type_simple_child ) | type_ref ;
 type_alias_decl = "type", id, "=", type ;
 
 (* Primitive operations *)
+expr_primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
+
 primop_2expr_keyword =
     "add"  | "sub" | "mul" | "div" | "mod"
   | "lt"   | "leq" | "gt"  | "geq" | "eq" | "neq"
@@ -3990,23 +3992,31 @@ primop_1expr2int_keyword =
     "bits" ;
 primop_1expr2int =
     primop_1expr2int_keyword , "(" , expr , "," , int , "," , int , ")" ;
-primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
 
 (* Expression definitions *)
 expr =
-    ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | rint ) , ")"
-  | type_enum , "(" , id , [ "," , expr ] , ")"
-  | reference
-  | "mux" , "(" , expr , "," , expr , "," , expr , ")"
-  | "read" , "(" , ref_expr , ")"
-  | primop ;
+  reference
+  | expr_lit
+  | expr_enum
+  | expr_mux
+  | expr_read
+  | expr_primop ;
+
+expr_lit = ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | rint ) , ")" ;
+expr_enum = type_enum , "(" , id , [ "," , expr ] , ")"
+expr_mux = "mux" , "(" , expr , "," , expr , "," , expr , ")" ;
+expr_read = "read" , "(" , ref_expr , ")" ;
+
+ref_expr = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
+           | static_reference ;
+
 static_reference = id
                  | static_reference , "." , id
                  | static_reference , "[" , int , "]" ;
+
 reference = static_reference
           | reference , "[" , expr , "]" ;
-ref_expr = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
-           | static_reference ;
+
 property_literal_expr = "Integer", "(", int, ")" ;
 property_expr = static_reference | property_literal_expr ;
 

--- a/spec.md
+++ b/spec.md
@@ -4127,40 +4127,42 @@ primop_1expr     = primop_1expr_keyword , "(" , expr , ")" ;
 primop_1expr1int = primop_1expr1int_keyword , "(", expr , "," , int , ")" ;
 primop_1expr2int = primop_1expr2int_keyword , "(" , expr , "," , int , "," , int , ")" ;
 
-(* In-line Annotations *)
+(* Tokens: Annotations *)
 annotations = "%" , "[" , json_array , "]" ;
 
-(* Version definition *)
+(* Tokens: Version *)
 sem_ver = int , "."  , int , "." , int ;
 version = "FIRRTL" , "version" , sem_ver ;
 
-(* Whitespace definitions *)
+(* Tokens: Whitespace *)
 indent = " " , { " " } ;
 dedent = ? remove one level of indentation ? ;
 newline = ? a newline character ? ;
 
-(* Integer Literals *)
+(* Tokens: Integer Literals *)
+int = [ "-" ] , digit_dec , { digit_dec } ;
 digit_bin = "0" | "1" ;
 digit_oct = digit_bin | "2" | "3" | "4" | "5" | "6" | "7" ;
 digit_dec = digit_oct | "8" | "9" ;
 digit_hex = digit_dec
           | "A" | "B" | "C" | "D" | "E" | "F"
           | "a" | "b" | "c" | "d" | "e" | "f" ;
-int = [ "-" ] , digit_dec , { digit_dec } ;
 
-(* Radix-specified Integer Literals *)
+(* Tokens: Radix-specified Integer Literals *)
 rint =
     [ "-" ] , "0b" , digit_bin , { digit_bin }
   | [ "-" ] , "0o" , digit_oct , { digit_oct }
   | [ "-" ] , "0d" , digit_oct , { digit_dec }
   | [ "-" ] , "0h" , digit_hex , { digit_hex } ;
 
-(* String Literals *)
+(* Tokens: String Literals *)
 string = ? a string ? ;
 string_dq = '"' , string , '"' ;
 string_sq = "'" , string , "'" ;
 
-(* Identifiers define legal FIRRTL or Verilog names *)
+(* Tokens: Identifiers *)
+id = ( "_" | letter ) , { "_" | letter | digit_dec } | literal_id ;
+literal_id = "`" , ( "_" | letter | digit_dec ), { "_" | letter | digit_dec } , "`" ;
 letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
        | "H" | "I" | "J" | "K" | "L" | "M" | "N"
        | "O" | "P" | "Q" | "R" | "S" | "T" | "U"
@@ -4170,14 +4172,12 @@ letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
        | "o" | "p" | "q" | "r" | "s" | "t" | "u"
        | "v" | "w" | "x" | "y" | "z" ;
 
-literal_id = "`" , ( "_" | letter | digit_dec ), { "_" | letter | digit_dec } , "`" ;
-id = ( "_" | letter ) , { "_" | letter | digit_dec } | literal_id ;
-
-(* Fileinfo communicates Chisel source file and line/column info *)
-linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;
-lineinfo = string, " ", linecol ;
+(* Tokens: Info *)
 info = "@" , "[" , lineinfo, { ",", lineinfo }, "]" ;
+lineinfo = string, " ", linecol ;
+linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;
 
+(* Tokens: PrimOp Keywords *)
 primop_1expr_keyword =
     "asUInt" | "asSInt" | "asClock" | "asAsyncReset" | "cvt"
   | "neg"    | "not"

--- a/spec.md
+++ b/spec.md
@@ -3910,7 +3910,7 @@ said to have "internal" convention.
 (* Circuit Definition *)
 circuit =
   version , newline ,
-  "circuit" , id , ":" , [ annotations ] , [ info ] , newline , indent ,
+  "circuit" , ":" , [ annotations ] , [ info ] , newline , indent ,
     { decl } ,
   dedent ;
 
@@ -3923,7 +3923,7 @@ decl =
   | decl_type_alias ;
 
 decl_module =
-  "module" , id , ":" , [ info ] , newline , indent ,
+  [ "public" ], "module" , id , ":" , [ info ] , newline , indent ,
     { port , newline } ,
     { statement , newline } ,
   dedent ;

--- a/spec.md
+++ b/spec.md
@@ -3916,30 +3916,33 @@ circuit =
 
 (* Top-level Declarations *)
 top_level_decl =
-      module
-    | extmodule
-    | intmodule
-    | declgroup
-    | type_alias_decl ;
+    module
+  | extmodule
+  | intmodule
+  | declgroup
+  | type_alias_decl ;
 
-module = "module" , id , ":" , [ info ] , newline , indent ,
-           { port , newline } ,
-           { statement , newline } ,
-         dedent ;
+module =
+  "module" , id , ":" , [ info ] , newline , indent ,
+    { port , newline } ,
+    { statement , newline } ,
+  dedent ;
 
-extmodule = "extmodule" , id , ":" , [ info ] , newline , indent ,
-              { port , newline } ,
-              [ "defname" , "=" , id , newline ] ,
-              { "parameter" , id , "=" , type_param , newline } ,
-              { "ref" , static_reference , "is" ,
-                '"' , static_reference , '"' , newline } ,
-            dedent ;
+extmodule =
+  "extmodule" , id , ":" , [ info ] , newline , indent ,
+    { port , newline } ,
+    [ "defname" , "=" , id , newline ] ,
+    { "parameter" , id , "=" , type_param , newline } ,
+    { "ref" , static_reference , "is" ,
+      '"' , static_reference , '"' , newline } ,
+  dedent ;
 
-intmodule = "intmodule" , id , ":" , [ info ] , newline , indent ,
-              { port , newline } ,
-              "intrinsic" , "=" , id , newline ,
-              { "parameter" , "=" , ( int | string_dq ) , newline } ,
-            dedent ;
+intmodule =
+  "intmodule" , id , ":" , [ info ] , newline , indent ,
+    { port , newline } ,
+    "intrinsic" , "=" , id , newline ,
+    { "parameter" , "=" , ( int | string_dq ) , newline } ,
+  dedent ;
 
 declgroup =
   "declgroup" , id , string , ":" , [ info ] , newline , indent ,
@@ -3978,19 +3981,19 @@ conditional_reg =
     "reg" , id , ":" , type , expr , [ info ]
   | "regreset" , id , ":" , type , "," , expr , "," , expr , "," , expr , [info] ;
 
-circuit_component_mem = "mem" , id , ":" , [ info ] , newline , indent ,
-           "data-type" , "=>" , type , newline ,
-           "depth" , "=>" , int , newline ,
-           "read-latency" , "=>" , int , newline ,
-           "write-latency" , "=>" , int , newline ,
-           "read-under-write" , "=>" , read_under_write , newline ,
-           { "reader" , "=>" , id , newline } ,
-           { "writer" , "=>" , id , newline } ,
-           { "readwriter" , "=>" , id , newline } ,
-         dedent ;
+circuit_component_mem =
+  "mem" , id , ":" , [ info ] , newline , indent ,
+    "data-type" , "=>" , type , newline ,
+    "depth" , "=>" , int , newline ,
+    "read-latency" , "=>" , int , newline ,
+    "write-latency" , "=>" , int , newline ,
+    "read-under-write" , "=>" , read_under_write , newline ,
+    { "reader" , "=>" , id , newline } ,
+    { "writer" , "=>" , id , newline } ,
+    { "readwriter" , "=>" , id , newline } ,
+  dedent ;
 
 read_under_write =  "old" | "new" | "undefined" ;
-
 
 (* Connect-like Statements *)
 connectlike =
@@ -4000,25 +4003,23 @@ connectlike =
   | "define" , static_reference , "=" , expr_probe , [ info ]
   | "propassign" , static_reference , "," , property_expr , [ info ] ;
 
-
 (* Conditional Statements *)
 conditional =
     conditional_when
   | conditional_match ;
 
-conditional_when = "when" , expr , ":" [ info ] , newline ,
+conditional_when =
+  "when" , expr , ":" [ info ] , newline ,
     indent , statement, { statement } , dedent ,
-    [ "else" , ":" , indent , statement, { statement } , dedent ] ;
+  [ "else" , ":" , indent , statement, { statement } , dedent ] ;
 
-conditional_match = "match" , expr , ":" , [ info ] , newline ,
-    [ indent ,
-        { conditional_match_branch } ,
-      dedent ] ;
+conditional_match =
+  "match" , expr , ":" , [ info ] , newline ,
+  [ indent , { conditional_match_branch } , dedent ] ;
 
 conditional_match_branch =
   id , [ "(" , id , ")" ] , ":" , newline ,
-    [ indent , { statement } , dedent ] ;
-
+  [ indent , { statement } , dedent ] ;
 
 (* Command Statements *)
 command =
@@ -4035,18 +4036,15 @@ command =
     , ")" ,
     [ ":" , id ] , [ info ] ;
 
-
 (* Group Statement *)
-group = "group" , id , "of" , id , ":" , [ info ] , newline ,
-    indent ,
-      { port , newline } ,
-      { statement , newline } ,
-    dedent ;
-
+group =
+  "group" , id , "of" , id , ":" , [ info ] , newline , indent ,
+    { port , newline } ,
+    { statement , newline } ,
+  dedent ;
 
 (* Skip Statement *)
 skip = "skip" , [ info ] ;
-
 
 (* References *)
 static_reference =
@@ -4056,7 +4054,6 @@ static_reference =
 
 reference = static_reference
           | reference , "[" , expr , "]" ;
-
 
 (* Expressions *)
 expr =
@@ -4080,7 +4077,6 @@ property_expr = static_reference | property_literal_expr ;
 
 expr_primop = primop_2expr | primop_1expr | primop_1expr1int | primop_1expr2int ;
 
-
 (* Types *)
 type = ( [ "const" ] , type_hardware ) | type_probe ;
 
@@ -4090,7 +4086,6 @@ type_hardware =
   | type_vec
   | type_enum
   | id ;
-
 
 (* Ground Types *)
 type_ground =  type_ground_nowidth | type_ground_width ;
@@ -4107,31 +4102,25 @@ type_ground_width =
 
 width = "<" , int , ">" ;
 
-
 (* Bundle Types *)
 type_bundle = "{" , type_bundle_field , { type_bundle_field } , "}" ;
 type_bundle_field = [ "flip" ] , id , ":" , type ;
 
-
 (* Vec Types *)
 type_vec = type , "[" , int , "]" ;
-
 
 (* Enum Types *)
 type_enum = "{|" , { type_enum_alt } , "|}" ;
 type_enum_alt = id, [ ":" , type_constable ] ;
 
-
 (* Probe Types *)
 type_probe = ( "Probe" | "RWProbe" ) , "<", type , [ "," , id , "," ] ">" ;
-
 
 (* Primitive Operations *)
 primop_2expr     = primop_2expr_keyword , "(" , expr , "," , expr ")" ;
 primop_1expr     = primop_1expr_keyword , "(" , expr , ")" ;
 primop_1expr1int = primop_1expr1int_keyword , "(", expr , "," , int , ")" ;
 primop_1expr2int = primop_1expr2int_keyword , "(" , expr , "," , int , "," , int , ")" ;
-
 
 (* In-line Annotations *)
 annotations = "%" , "[" , json_array , "]" ;
@@ -4175,8 +4164,8 @@ letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
        | "h" | "i" | "j" | "k" | "l" | "m" | "n"
        | "o" | "p" | "q" | "r" | "s" | "t" | "u"
        | "v" | "w" | "x" | "y" | "z" ;
-literal_id =
-  "`" , ( "_" | letter | digit_dec ), { "_" | letter | digit_dec } , "`" ;
+
+literal_id = "`" , ( "_" | letter | digit_dec ), { "_" | letter | digit_dec } , "`" ;
 id = ( "_" | letter ) , { "_" | letter | digit_dec } | literal_id ;
 
 (* Fileinfo communicates Chisel source file and line/column info *)
@@ -4199,7 +4188,6 @@ primop_1expr1int_keyword =
     "pad" | "shl" | "shr" | "head" | "tail" ;
 
 primop_1expr2int_keyword = "bits" ;
-
 ```
 
 # Versioning Scheme of this Document

--- a/spec.md
+++ b/spec.md
@@ -4084,12 +4084,18 @@ conditional_when = "match" , expr , ":" , [ info ] , newline ,
 
 (* Commands *)
 command =
-  | "printf(" , expr , "," , expr , "," , string_dq , { "," , expr } , ")" , [ ":" , id ] , [ info ]
-  | "stop(" , expr , "," , expr , "," , int , ")" , [ info ] ;
+  "stop" , "(" , expr , "," , expr , "," , int , ")" , [ info ]
   | "force" , "(" , expr , "," , expr , "," , ref_expr , "," , expr , ")"
   | "force_initial" , "(" , ref_expr , "," , expr , ")"
-  | "release" , "(" , expr , "," , expr , "," , ref_expr , ")" ;
+  | "release" , "(" , expr , "," , expr , "," , ref_expr , ")"
   | "release_initial" , "(" , ref_expr , ")"
+  | "printf" , "(" ,
+        expr , "," ,
+        expr , "," ,
+        string_dq ,
+        { "," , expr }
+    , ")" ,
+    [ ":" , id ] , [ info ] ;
 
 (* Groups *)
 group = "group" , id , "of" , id , ":" , [ info ] , newline ,

--- a/spec.md
+++ b/spec.md
@@ -3952,18 +3952,43 @@ lineinfo = string, " ", linecol ;
 info = "@" , "[" , lineinfo, { ",", lineinfo }, "]" ;
 
 (* Type definitions *)
+type = ( [ "const" ] , type_constable ) | type_probe ;
+
+type_constable =
+    type_ground
+  | type_bundle
+  | type_vec
+  | type_enum
+  | id ;
+
+(* Ground Types *)
+type_ground =  type_ground_nowidth | type_ground_width ;
+
+type_ground_nowidth =
+    "Clock"
+  | "Reset"
+  | "AsyncReset" ;
+
+type_ground_width =
+    "UInt" , [ width ]
+  | "SInt" , [ width ]
+  | "Analog" , [ width ] ;
+
 width = "<" , int , ">" ;
-type_ground = "Clock" | "Reset" | "AsyncReset"
-            | ( "UInt" | "SInt" | "Analog" ) , [ width ] ;
-type_enum = "{|" , { field_enum } , "|}" ;
-field_enum = id, [ ":" , type_simple_child ] ;
-type_aggregate = "{" , field , { field } , "}"
-               | type , "[" , int , "]" ;
-type_ref = ( "Probe" | "RWProbe" ) , "<", type , [ "," , id , "," ] ">" ;
-field = [ "flip" ] , id , ":" , type ;
-type_property = "Integer" ;
-type_simple_child = type_ground | type_enum | type_aggregate | id ;
-type = ( [ "const" ] , type_simple_child ) | type_ref ;
+
+(* Bundle Types *)
+type_bundle = "{" , type_bundle_field , { type_bundle_field } , "}" ;
+type_bundle_field = [ "flip" ] , id , ":" , type ;
+
+(* Vec Types *)
+type_vec = type , "[" , int , "]" ;
+
+(* Enum Types *)
+type_enum = "{|" , { type_enum_alt } , "|}" ;
+type_enum_alt = id, [ ":" , type_constable ] ;
+
+(* Probe Types *)
+type_probe = ( "Probe" | "RWProbe" ) , "<", type , [ "," , id , "," ] ">" ;
 
 (* Type alias declaration *)
 type_alias_decl = "type", id, "=", type ;
@@ -3993,7 +4018,7 @@ primop_1expr2int_keyword =
 primop_1expr2int =
     primop_1expr2int_keyword , "(" , expr , "," , int , "," , int , ")" ;
 
-(* Expression definitions *)
+(* Expressions *)
 expr =
     reference
   | expr_lit
@@ -4129,7 +4154,9 @@ intmodule = "intmodule" , id , ":" , [ info ] , newline , indent ,
             dedent ;
 
 port = ( "input" | "output" ) , id , ":" , (type | type_property) , [ info ] ;
+
 type_param = int | string_dq | string_sq ;
+type_property = "Integer" ;
 
 (* Group definitions *)
 declgroup =

--- a/spec.md
+++ b/spec.md
@@ -4032,9 +4032,10 @@ expr_read = "read" , "(" , expr_probe , ")" ;
 expr_probe = ( "probe" | "rwprobe" ) , "(" , static_reference , ")"
            | static_reference ;
 
-static_reference = id
-                 | static_reference , "." , id
-                 | static_reference , "[" , int , "]" ;
+static_reference =
+    id
+  | static_reference , "." , id
+  | static_reference , "[" , int , "]" ;
 
 reference = static_reference
           | reference , "[" , expr , "]" ;
@@ -4104,7 +4105,7 @@ conditional_match = "match" , expr , ":" , [ info ] , newline ,
 
 conditional_match_branch =
   id , [ "(" , id , ")" ] , ":" , newline ,
-    [ indent , { statement } , dedent ]
+    [ indent , { statement } , dedent ] ;
 
 (* Commands *)
 command =

--- a/spec.md
+++ b/spec.md
@@ -4048,7 +4048,7 @@ skip = "skip" , [ info ] ;
 (* References *)
 reference =
     reference_static
-  | reference_dynamic
+  | reference_dynamic ;
 
 reference_static =
     id
@@ -4067,7 +4067,7 @@ expr =
   | expr_read
   | expr_primop ;
 
-expr_reference = reference
+expr_reference = reference ;
 expr_lit = ( "UInt" | "SInt" ) , [ width ] , "(" , ( int | rint ) , ")" ;
 expr_enum = type_enum , "(" , id , [ "," , expr ] , ")" ;
 expr_mux = "mux" , "(" , expr , "," , expr , "," , expr , ")" ;

--- a/spec.md
+++ b/spec.md
@@ -3948,7 +3948,7 @@ id = ( "_" | letter ) , { "_" | letter | digit_dec } | literal_id ;
 
 (* Fileinfo communicates Chisel source file and line/column info *)
 linecol = digit_dec , { digit_dec } , ":" , digit_dec , { digit_dec } ;
-lineinfo = string, " ", linecol
+lineinfo = string, " ", linecol ;
 info = "@" , "[" , lineinfo, { ",", lineinfo }, "]" ;
 
 (* Type definitions *)
@@ -4124,7 +4124,7 @@ declgroup =
 annotations = "%" , "[" , json_array , "]" ;
 
 (* Version definition *)
-sem_ver = int , "."  , int , "." , int
+sem_ver = int , "."  , int , "." , int ;
 version = "FIRRTL" , "version" , sem_ver ;
 
 (* Circuit definition *)

--- a/spec.md
+++ b/spec.md
@@ -3995,7 +3995,7 @@ primop_1expr2int =
 
 (* Expression definitions *)
 expr =
-  reference
+    reference
   | expr_lit
   | expr_enum
   | expr_mux
@@ -4157,8 +4157,6 @@ circuit =
   "circuit" , id , ":" , [ annotations ] , [ info ] , newline , indent ,
     { top_level_decl } ,
   dedent ;
-
-
 ```
 
 # Versioning Scheme of this Document


### PR DESCRIPTION
As far as I can tell, the grammar for FIRRTL was originally created with two design points:

- Make a pretty, whitespace-sensitive language.
- Just make it work.

The current grammar is overgrown and in need of a refactoring. I have made several changes to help illuminate the structure of the FIRRTL language:

- The organization of the production rules has been tightened up a bit
- Several grammar rules have been renamed for uniformity or clarity.
-The `expr` production rule  has been change to an alternate list of non-terminals
-The `statement` production rule  has been change to an alternate list of non-terminals

The `expr` and `statement` production rules now allow you to glance at the grammar and get a reasonable idea of what a language-level AST should look like. For `statement` especially, you can see the taxonomy of statements more clearly: there are circuit components, connect-like statements, conditional blocks, commands, groups, and the `skip` statement.

While I was careful to keep this grammar equivalent, it's hard for me to verify. Please review these changes carefully, and ask to discuss any changes that seem questionable. The PR is best reviewed commit-by-commit. Even if the grammar has minor mistakes, the increase in clarity should be a net-positive.

I have another branch where I make two additional, more controversial changes:
- the removal of the lexical rules for tokens (ie, `dedent` is already not defined, so why not also leave `int` `string` `id` and `info` undefined as well?)
- the replacement of `primop` with a much simpler variant that doesn't bake the primitive operations into the grammar. (This requires elaboration on when a `primop` expression is well-formed in the prose).

