### PR TITLE
Fix grammar of `parameter` in `intmodule`

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3379,7 +3379,7 @@ decl_intmodule =
   "intmodule" , id , ":" , [ info ] , newline , indent ,
     { port , newline } ,
     "intrinsic" , "=" , id , newline ,
-    { "parameter" , "=" , ( int | string_dq ) , newline } ,
+    { "parameter" , id , "=" , ( int | string_dq ) , newline } ,
   dedent ;
 
 decl_group =


### PR DESCRIPTION
`parameter`s in `intmodule` should have names, for example

```firrtl
intmodule MyIntModule :
  input in : UInt
  output out : UInt<8>
  intrinsic = testIntrinsic1
  parameter FORMAT = "xyz_timeout=%d\n"
  parameter DEFAULT = 0
  parameter WIDTH = 32
  parameter DEPTH = 32.42
```