### PR TITLE
[nfc] Change line-wrap policy in `CONTRIBUTORS.md` and add missing revisions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 ## Writing
 
-* Wrap markdown lines to 80 characters.
+* One sentence per line.
+  No linewraps.
 * Inline FIRRTL code snippets should be tagged as FIRRTL code with `{.firrtl}`.
   * This isn't recognized by GitHub, but is used for the PDF generation.
 * Match terminology and capitalization preferences used elsewhere by default.

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -9,6 +9,7 @@ revisionHistory:
         Change circuits to support any number of public modules which may have disjoint instance hierarchies.
       - Rename a "FIRRTL Language Definition" to "Grammar".
       - Rename "Details about Syntax" to "Notes on Syntax".
+      - Add section "Circuit Components".
     abi:
       - Add ABI for public modules and filelist output.
       - Changed ABI for group and ref generated files.


### PR DESCRIPTION
The new policy for line formatting is in `CONTRIBUTING.md`: One sentence per line.
This makes diffs easier to read and the text easier to shuffle around.

This PR also adds in a line I forgot to include in `revision-history.yaml` in #135.