### PR TITLE
[patch] Types Section Reorg

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -10,6 +10,7 @@
     </list>
     <list name="keywords">
       <item>input</item>
+      <item>type</item>
       <item>output</item>
       <item>defname</item>
       <item>parameter</item>

--- a/spec.md
+++ b/spec.md
@@ -670,28 +670,6 @@ connect z, asUInt(y)
 
 See [@sec:primitive-operations] for more details on casting.
 
-### Analog Type
-
-The analog type specifies that a wire or port can be attached to multiple drivers.
-`Analog`{.firrtl} cannot be used as part of the type of a node or register, nor can it be used as part of the datatype of a memory.
-In this respect, it is similar to how `inout`{.firrtl} ports are used in Verilog, and FIRRTL analog signals are often used to interface with external Verilog or VHDL IP.
-
-In contrast with all other ground types, analog signals cannot appear on either side of a connection statement.
-Instead, analog signals are attached to each other with the commutative `attach`{.firrtl} statement.
-An analog signal may appear in any number of attach statements, and a legal circuit may also contain analog signals that are never attached.
-The only primitive operations that may be applied to analog signals are casts to other signal types.
-
-When an analog signal appears as a field of an aggregate type, the aggregate cannot appear in a standard connection statement.
-
-As with integer types, an analog type can represent a multi-bit signal.
-When analog signals are not given a concrete width, their widths are inferred according to a highly restrictive width inference rule, which requires that the widths of all arguments to a given attach operation be identical.
-
-``` firrtl
-Analog<1>  ; 1-bit analog type
-Analog<32> ; 32-bit analog type
-Analog     ; analog type with inferred width
-```
-
 ## Aggregate Types
 
 FIRRTL supports three aggregate types: vectors, bundles, and enumeration.
@@ -787,6 +765,28 @@ In the following example, all variants have the type `UInt<0>`{.firrtl}.
 
 ``` firrtl
 {|a, b, c|}
+```
+
+## Analog Type
+
+The analog type specifies that a wire or port can be attached to multiple drivers.
+`Analog`{.firrtl} cannot be used as part of the type of a node or register, nor can it be used as part of the datatype of a memory.
+In this respect, it is similar to how `inout`{.firrtl} ports are used in Verilog, and FIRRTL analog signals are often used to interface with external Verilog or VHDL IP.
+
+In contrast with all other ground types, analog signals cannot appear on either side of a connection statement.
+Instead, analog signals are attached to each other with the commutative `attach`{.firrtl} statement.
+An analog signal may appear in any number of attach statements, and a legal circuit may also contain analog signals that are never attached.
+The only primitive operations that may be applied to analog signals are casts to other signal types.
+
+When an analog signal appears as a field of an aggregate type, the aggregate cannot appear in a standard connection statement.
+
+As with integer types, an analog type can represent a multi-bit signal.
+When analog signals are not given a concrete width, their widths are inferred according to a highly restrictive width inference rule, which requires that the widths of all arguments to a given attach operation be identical.
+
+``` firrtl
+Analog<1>  ; 1-bit analog type
+Analog<32> ; 32-bit analog type
+Analog     ; analog type with inferred width
 ```
 
 ## Reference Types

--- a/spec.md
+++ b/spec.md
@@ -1055,9 +1055,7 @@ module Example:
   input intProp : Integer ; an input port of Integer property type
 ```
 
-## Type Modifiers
-
-### Constant Type
+## Constant Type
 
 A constant type is a type whose value is guaranteed to be unchanging at circuit execution time.
 Constant is a constraint on the mutability of the value, it does not imply a literal value at a point in the emitted design.
@@ -1082,7 +1080,7 @@ In such case, the value of the port is not known, but that it is non-mutating at
 
 The indexing of a constant aggregate produces a constant of the appropriate type for the element.
 
-#### A note on implementation
+### A note on implementation
 
 Constant types are a restriction on FIRRTL types.
 Therefore, FIRRTL structures which would be expected to produce certain Verilog structures will produce the same structure if instantiated with a constant type.

--- a/spec.md
+++ b/spec.md
@@ -1025,6 +1025,22 @@ Consequently, `{a:UInt, b:UInt}`{.firrtl} is not equivalent to `{b:UInt, a:UInt}
 
 Two property types are equivalent if they are the same concrete property type.
 
+## Width Inference
+
+For all circuit components declared with unspecified widths,
+the FIRRTL compiler will infer the minimum possible width that maintains the legality of all its incoming connections.
+If a circuit component has no incoming connections, and the width is unspecified, then an error is thrown to indicate that the width could not be inferred.
+
+For module input ports with unspecified widths, the inferred width is the minimum possible width that maintains the legality of all incoming connections to all instantiations of the module.
+
+The width of a ground-typed multiplexer expression is the maximum of its two corresponding input widths.
+For multiplexing aggregate-typed expressions, the resulting widths of each leaf sub-element is the maximum of its corresponding two input leaf sub-element widths.
+
+The width of each primitive operation is detailed in [@sec:primitive-operations].
+
+The width of constant integer expressions is detailed in their respective sections.
+
+
 # Connections
 
 ## Flow
@@ -2778,21 +2794,6 @@ module MyModule :
 The probed expression must be a static reference.
 
 See [@sec:probe-types;@sec:probe] for more details on probe references and their use.
-
-# Width Inference
-
-For all circuit components declared with unspecified widths,
-the FIRRTL compiler will infer the minimum possible width that maintains the legality of all its incoming connections.
-If a circuit component has no incoming connections, and the width is unspecified, then an error is thrown to indicate that the width could not be inferred.
-
-For module input ports with unspecified widths, the inferred width is the minimum possible width that maintains the legality of all incoming connections to all instantiations of the module.
-
-The width of a ground-typed multiplexer expression is the maximum of its two corresponding input widths.
-For multiplexing aggregate-typed expressions, the resulting widths of each leaf sub-element is the maximum of its corresponding two input leaf sub-element widths.
-
-The width of each primitive operation is detailed in [@sec:primitive-operations].
-
-The width of constant integer expressions is detailed in their respective sections.
 
 # Namespaces
 

--- a/spec.md
+++ b/spec.md
@@ -1029,30 +1029,6 @@ module Top:
   node consumer_debug = read(c.out.cref); ; Consumer-side signal
 ```
 
-## Type Alias
-
-A type alias is a mechanism to assign names to existing FIRRTL types.
-Type aliases enables their reuse across multiple declarations.
-
-```firrtl
-type WordType = UInt<32>
-type ValidType = UInt<1>
-type Data = {w: WordType, valid: ValidType, flip ready: UInt<1>}
-type AnotherWordType = UInt<32>
-
-module TypeAliasMod:
-  input in: Data
-  output out: Data
-  wire w: AnotherWordType
-  connect w, in.w
-  ...
-```
-
-The `type` declaration is globally defined and all named types exist in the same namespace and thus must all have a unique name.
-Type aliases do not share the same namespace as modules; hence it is allowed for type aliases to conflict with module names.
-Note that when we compare two types, the equivalence is determined solely by their structures.
-For instance types of `w`{.firrtl} and `in.w`{.firrtl} are equivalent in the example above even though they are different type alias.
-
 ## Property Types
 
 FIRRTL property types represent information about the circuit that is not hardware.
@@ -1137,6 +1113,29 @@ More precisely, a passive type is defined recursively:
 
 Registers and memories may only be parametrized over passive types.
 
+## Type Alias
+
+A type alias is a mechanism to assign names to existing FIRRTL types.
+Type aliases enables their reuse across multiple declarations.
+
+```firrtl
+type WordType = UInt<32>
+type ValidType = UInt<1>
+type Data = {w: WordType, valid: ValidType, flip ready: UInt<1>}
+type AnotherWordType = UInt<32>
+
+module TypeAliasMod:
+  input in: Data
+  output out: Data
+  wire w: AnotherWordType
+  connect w, in.w
+  ...
+```
+
+The `type` declaration is globally defined and all named types exist in the same namespace and thus must all have a unique name.
+Type aliases do not share the same namespace as modules; hence it is allowed for type aliases to conflict with module names.
+Note that when we compare two types, the equivalence is determined solely by their structures.
+For instance types of `w`{.firrtl} and `in.w`{.firrtl} are equivalent in the example above even though they are different type alias.
 
 ## Type Equivalence
 


### PR DESCRIPTION
This PR re-orders a few sections under the Types section. The easiest way to review this is commit-by-commit.
Also, add `type` as a keyword for syntax highlighting.

No copy has been changed.

Some high-level points:

- Float property types up, since they are the four tier of the standard taxonomy (along with ground and aggregate and reference types).
- Move passive types up, since that feature is central and very stable.
- The probes section had a bunch of copy that isn't relevant to the type system and has been moved to the section of probes below.

All of this is prepwork for a heavy upcoming rewrite of the types section. 