### PR TITLE
[patch] Rewrite Types Section

### DIFF
--- a/abi.md
+++ b/abi.md
@@ -302,6 +302,11 @@ The padding for each payload is set to ensure all padded payloads have the same 
 
 Property types have no defined ABI, and may not affect any other guarantees of the ABI.
 
+TODO: 0-width vectors?
+
+Property types have no defined ABI, and may not affect any other guarantees of
+the ABI.
+
 ### Constant Types
 
 Constant types are a restriction on FIRRTL types.

--- a/abi.md
+++ b/abi.md
@@ -302,11 +302,6 @@ The padding for each payload is set to ensure all padded payloads have the same 
 
 Property types have no defined ABI, and may not affect any other guarantees of the ABI.
 
-TODO: 0-width vectors?
-
-Property types have no defined ABI, and may not affect any other guarantees of
-the ABI.
-
 ### Constant Types
 
 Constant types are a restriction on FIRRTL types.

--- a/abi.md
+++ b/abi.md
@@ -312,7 +312,6 @@ It is not intended that constants are a replacement for parameterization.
 Constant typed values have no particular meta-programming capability.
 It is, for example, expected that a module with a constant input port be fully compilable to non-parameterized Verilog.
 
-
 # Versioning Scheme of this Document
 
 This is the versioning scheme that applies to version 1.0.0 and later.

--- a/abi.md
+++ b/abi.md
@@ -302,6 +302,17 @@ The padding for each payload is set to ensure all padded payloads have the same 
 
 Property types have no defined ABI, and may not affect any other guarantees of the ABI.
 
+### Constant Types
+
+Constant types are a restriction on FIRRTL types.
+Therefore, FIRRTL structures which would be expected to produce certain Verilog structures will produce the same structure if instantiated with a constant type.
+For example, an input port of type `const UInt`{.firrtl} will result in a port in the Verilog, if under the same conditions an input port of type `UInt`{.firrtl} would have.
+
+It is not intended that constants are a replacement for parameterization.
+Constant typed values have no particular meta-programming capability.
+It is, for example, expected that a module with a constant input port be fully compilable to non-parameterized Verilog.
+
+
 # Versioning Scheme of this Document
 
 This is the versioning scheme that applies to version 1.0.0 and later.

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -11,6 +11,7 @@ revisionHistory:
       - Rename "Details about Syntax" to "Notes on Syntax".
       - Add section "Circuit Components".
       - Reorganized statements section.
+      - Rewrite of the Types section.
     abi:
       - Add ABI for public modules and filelist output.
       - Changed ABI for group and ref generated files.

--- a/spec.md
+++ b/spec.md
@@ -593,7 +593,7 @@ SInt<32> ; 32-bit signed integer
 
 Both `UInt<0>`{.firrtl} and `SInt<0>`{.firrtl} are valid types.
 They are considered to have only a single value representing zero (written as either `UInt<0>(0)`{.firrtl} or `SInt<0>(0)`{.firrtl}).
-They are always zero extended, and thus, behave like zero when they are extended to a positive width.
+They behave like zero when they are extended to a positive width integer type.
 
 TODO: Talk about how zero-bit integers are lowered. And how they can be stripped out.
 TODO: There was an example here:
@@ -616,6 +616,8 @@ In FIRRTL, we have the option of using both synchronous or asynchronous resets.
 
 The synchronous reset type is simply a 1-bit unsigned integer: `UInt<1>`{.firrtl}.
 The asynchronous reset type is `AsyncReset`{.firrtl}.
+
+TODO: mention `regreset`.
 
 The reset types also have the uninferred form: `Reset`{.firrtl} (see [@sec:reset-inference]).
 
@@ -676,7 +678,7 @@ module Processor :
 ```
 
 This defines a module `Processor` with a single input port `enq` which enqueues data using a ready-valid interface.
-Because `enq` is a single port, we can connect to it with a single `connect` statement (see [@sec:connects]).
+Because `enq` is a single port, we can connect to it with a single `connect` statement (see [@sec:connections]).
 In the final hardware, however, while the `word` and `valid` fields point *into* the module, this port has a flipped field `ready` which points *out of* the module instead.
 
 The types of each field may be any type, including other aggregate types.
@@ -728,7 +730,6 @@ When analog signals are not given a concrete width, their widths are inferred ac
 ``` firrtl
 Analog<1>  ; 1-bit analog type
 Analog<32> ; 32-bit analog type
-Analog     ; analog type with inferred width
 ```
 
 ## Probe Types
@@ -742,11 +743,11 @@ Probe types are not synthesizable.
 There are two probe types, `Probe<T>`{.firrtl} is a read-only variant and `RWProbe<T>`{.firrtl} is a read-write variant.
 In both cases, `T`{.firrtl} must be a passive type (see [@sec:passive-types]).
 
-Both `Probe`{.firrtl} and `RWProbe`{.firrtl} may be read from using the `read` expression.
-`RWProbe`{.firrtl} may also be forced using the `force` and `force_initial` commands.
-However, when forcing is not needed, the `Probe`{.firrtl} allows more aggressive optimization.
-
 They are created using the `probe`{.firrtl} and `rwprobe`{.firrtl} expressions (see [@sec:probes]).
+
+Both `Probe`{.firrtl} and `RWProbe`{.firrtl} may be read from using the `read`{.firrtl} expression (see [@sec:reading-probe-references]).
+`RWProbe`{.firrtl} may also be forced using the `force`{.firrtl} and `force_initial`{.firrtl} commands (see [@sec:force-and-release]).
+However, when forcing is not needed, the `Probe`{.firrtl} allows more aggressive optimization.
 
 Probe references must always be able to be statically traced to their target, or to an external module's output reference.
 Reference-type ports are statically routed through the design using the `define`{.firrtl} statement.
@@ -757,9 +758,9 @@ When associated with an optional group, the reference type may only be driven fr
 Examples:
 
 ```firrtl
-Probe<UInt> ; readable reference to unsigned integer with inferred width
-RWProbe<{x: {y: UInt}}> ; readable and forceable reference to bundle
-Probe<UInt, A.B> ; readable reference associated with group A.B
+Probe<UInt<8>>                         ; readable probe to an 8-bit unsigned integer
+RWProbe<{ x : UInt<1>, y : UInt<1> }>  ; read-writable probe to bundle
+Probe<UInt, A.B>                       ; readable probe associated with group A.B
 ```
 
 For details of how to read and write through probe types, see [@sec:reading-probe-references;@sec:force-and-release].
@@ -773,7 +774,7 @@ The following example demonstrates some legal and illegal expressions:
 
 ```firrtl
 module NoSubAccessesWithProbes :
-  input x : {a : Probe<UInt[2]>, b : UInt}[3]
+  input x : { a : Probe<UInt[2]>, b : UInt }[3]
   input i : UInt
   input c : const UInt
   output p : Probe<UInt>
@@ -943,6 +944,12 @@ For multiplexing aggregate-typed expressions, the resulting widths of each leaf 
 The width of each primitive operation is detailed in [@sec:primitive-operations].
 
 The width of constant integer expressions is detailed in their respective sections.
+
+```firrtl
+UInt
+SInt
+Analog
+```
 
 ### Reset Inference
 

--- a/spec.md
+++ b/spec.md
@@ -934,30 +934,6 @@ Type aliases do not share the same namespace as modules; hence it is allowed for
 TODO: Is there a rationale for this design choice?
 TODO: Namespaces
 
-## Type Equivalence
-
-The type equivalence relation is used to determine whether a connection between two components is legal.
-See [@sec:connections] for further details about connect statements.
-
-An unsigned integer type is always equivalent to another unsigned integer type regardless of bit width, and is not equivalent to any other type.
-Similarly, a signed integer type is always equivalent to another signed integer type regardless of bit width, and is not equivalent to any other type.
-
-Clock types are equivalent to clock types, and are not equivalent to any other type.
-
-An uninferred `Reset`{.firrtl} can be connected to another `Reset`{.firrtl}, `UInt`{.firrtl} of unknown width, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}.
-It cannot be connected to both a `UInt`{.firrtl} and an `AsyncReset`{.firrtl}.
-
-The `AsyncReset`{.firrtl} type can be connected to another `AsyncReset`{.firrtl} or to a `Reset`{.firrtl}.
-
-Two enumeration types are equivalent if both have the same number of variants, and both the enumerations' i'th variants have matching names and equivalent types.
-
-Two vector types are equivalent if they have the same length, and if their element types are equivalent.
-
-Two bundle types are equivalent if they have the same number of fields, and both the bundles' i'th fields have matching names and orientations, as well as equivalent types.
-Consequently, `{a:UInt, b:UInt}`{.firrtl} is not equivalent to `{b:UInt, a:UInt}`{.firrtl}, and `{a: {flip b:UInt}}`{.firrtl} is not equivalent to `{flip a: {b: UInt}}`{.firrtl}.
-
-Two property types are equivalent if they are the same concrete property type.
-
 ## Type Inference
 
 FIRRTL has support for limited type inference.
@@ -1094,6 +1070,32 @@ Wires and registers may appear "on either side of a connect statement".
 Ports are always considered from the perspective of "inside the module".
 Moreover, input ports may only appear "on the left side" of a connect, while output ports may only appear "on the right side" of a connect.
 Finally, while submodules instances and memories are strictly sources, they interact with the sub-field rule below, allowing connections to their input ports
+
+## Type Equivalence
+
+TODO: Replace this with a relation like "S 'coerces to' T".
+
+The type equivalence relation determines whether one values of one type can be coerced into values of another.
+
+An unsigned integer type is always equivalent to another unsigned integer type regardless of bit width, and is not equivalent to any other type.
+Similarly, a signed integer type is always equivalent to another signed integer type regardless of bit width, and is not equivalent to any other type.
+
+Clock types are equivalent to clock types, and are not equivalent to any other type.
+
+An uninferred `Reset`{.firrtl} can be connected to another `Reset`{.firrtl}, `UInt`{.firrtl} of unknown width, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}.
+It cannot be connected to both a `UInt`{.firrtl} and an `AsyncReset`{.firrtl}.
+
+The `AsyncReset`{.firrtl} type can be connected to another `AsyncReset`{.firrtl} or to a `Reset`{.firrtl}.
+
+Two enumeration types are equivalent if both have the same number of variants, and both the enumerations' i'th variants have matching names and equivalent types.
+
+Two vector types are equivalent if they have the same length, and if their element types are equivalent.
+
+Two bundle types are equivalent if they have the same number of fields, and both the bundles' i'th fields have matching names and orientations, as well as equivalent types.
+Consequently, `{a:UInt, b:UInt}`{.firrtl} is not equivalent to `{b:UInt, a:UInt}`{.firrtl}, and `{a: {flip b:UInt}}`{.firrtl} is not equivalent to `{flip a: {b: UInt}}`{.firrtl}.
+
+Two property types are equivalent if they are the same concrete property type.
+
 
 ## The Connect Statement
 

--- a/spec.md
+++ b/spec.md
@@ -814,9 +814,10 @@ Property types are legal in the following constructs:
 
 * Port declarations on modules and external modules
 
-### Integer Property Types
+### Integer Type
 
-Integer property types represent arbitrary precision signed integer values.
+The `Integer` type represents an numeric property.
+It can represent arbitrary-precision signed integer values.
 
 ``` firrtl
 module Example:

--- a/spec.md
+++ b/spec.md
@@ -837,12 +837,12 @@ All integer literals are `const`{.firrtl}.
 For example, `UInt<8>(42)`{.firrtl} has type `const UInt<8>`{.firrtl}.
 
 Ports can have a `const`{.firrtl} type, and thus, a module may receive constant values from its parent module.
-This may even happen in `public`{.firrtl} modules, and so the value of a `const`{.firrtl} type need not be known statically (see TODO).
+This may even happen in `public`{.firrtl} modules, and so the value of a `const`{.firrtl} type need not be known statically (see [@sec:public-modules]).
 
-Typically, primitive operations will result in a `const`{.firrtl} type whenever each of its inputs are `const`{.firrtl} (see prim ops TODO).
+Typically, primitive operations will result in a `const`{.firrtl} type whenever each of its inputs are `const`{.firrtl} (see [@sec:primitive-operations]).
 For example, `add(x, y)`{.firrtl} will be `const`{.firrtl} if both `x`{.firrtl} and `y`{.firrtl} are `const`{.firrtl}.
 
-The resulting type of a multiplexer expression, `mux(s, a, b)`{.firrtl}, will be `const`{.firrtl} if all of `s`{.firrtl}, `a`{.firrtl}, and `b`{.firrtl} are `const`{.firrtl} (see TODO).
+The resulting type of a multiplexer expression, `mux(s, a, b)`{.firrtl}, will be `const`{.firrtl} if all of `s`{.firrtl}, `a`{.firrtl}, and `b`{.firrtl} are `const`{.firrtl} (see [@sec:multiplexers]).
 
 An expression of type `const T`{.firrtl} is implicitly upcast to type `T`{.firrtl} whenever it would be required to make a primitive operation, mux expression, or connect statement typecheck.
 
@@ -890,17 +890,8 @@ Type aliases have structural identity.
 In other words, when we compare two types, we expand all type aliases recursively until we are left with type expressions that have no aliases.
 For instance, in the above example, we can connect `in.w`{.firrtl} to `w`{.firrtl} since their types, `WordType` and `AnotherWordType` respectively, both expand to `UInt<32>`{.firrtl}.
 
-TODO: Type equivalence should mention this.
-TODO: Can type aliases be recursive? Are they in scope of each other?
-
-TODO: Mention that `type` is a top-level decl.
-TODO: How global? Global to the `circuit`?
-
 The `type`{.firrtl} declaration is globally defined and all named types exist in the same namespace and thus must all have a unique name.
 Type aliases do not share the same namespace as modules; hence it is allowed for type aliases to conflict with module names.
-
-TODO: Is there a rationale for this design choice?
-TODO: Namespaces
 
 ## Type Inference
 
@@ -911,7 +902,7 @@ Width inference and reset inference.
 ### Width Inference
 
 Normally, the three integer ground types are written with explicit bit widths.
-The bit widths are given in angel brackets, such as the 8 in `UInt<8>`{.firrtl}.
+The bit widths are given in angel brackets, such as the `8`{.firrtl} in `UInt<8>`{.firrtl}.
 This is called the **uninferred** variant of the type.
 
 FIRRTL also supports an **inferred** variant of these types.
@@ -926,16 +917,15 @@ Analog
 When an inferred variant of an integer ground type is used, FIRRTL will calculate the minimum width needed for it.
 It is an error if the minimum size cannot be calculated.
 
-The width of a mux expression is the maximum of its two corresponding input widths.
-For multiplexing aggregate-typed expressions, the resulting widths of each leaf sub-element is the maximum of its corresponding two input leaf sub-element widths.
-TODO: Are these anywhere near complete enough to bother mentioning them? It seems better to just remove this paragraph until we have the exact rules.
+For example, the width of a multiplexer expression is the maximum of its two corresponding input widths.
 
 The width of each primitive operation is detailed in [@sec:primitive-operations].
-TODO: What "width"? The minimum widths?
 
 ### Reset Inference
 
-The following example shows an uninferred reset that will get inferred to a synchronous reset.
+The uninferred `Reset`{.firrtl} type will be inferred to either a synchronous reset `UInt<1>`{.firrtl} or to an asynchronous reset `AsyncReset`{.firrtl}.
+
+The following example shows an inferred reset that will get inferred to a synchronous reset.
 
 ``` firrtl
 input a : UInt<1>

--- a/spec.md
+++ b/spec.md
@@ -763,7 +763,7 @@ Probe<UInt<8>, A.B>     ; A.B is an optional group
 RWProbe<UInt<8>, A.B>
 ```
 
-Probes are generally lowered to hierarchical expressions in Verilog.
+Probes are generally lowered to hierarchical names in Verilog.
 For details, see the FIRRTL ABI Specification.
 
 ## Property Types
@@ -910,7 +910,7 @@ Width inference and reset inference.
 ### Width Inference
 
 Normally, the three integer ground types are written with explicit bit widths.
-The bit widths are given in angel brackets, such as the `8`{.firrtl} in `UInt<8>`{.firrtl}.
+The bit widths are given in angle brackets, such as the `8`{.firrtl} in `UInt<8>`{.firrtl}.
 This is called the **uninferred** variant of the type.
 
 FIRRTL also supports an **inferred** variant of these types.
@@ -1019,7 +1019,7 @@ Similarly, a signed integer type is always equivalent to another signed integer 
 
 Clock types are equivalent to clock types, and are not equivalent to any other type.
 
-An uninferred `Reset`{.firrtl} can be connected to another `Reset`{.firrtl}, `UInt`{.firrtl} of unknown width, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl}.
+An uninferred `Reset`{.firrtl} can be connected to another `Reset`{.firrtl}, `UInt`{.firrtl} of unknown width, `UInt<1>`{.firrtl}, or `AsyncReset`{.firrtl} (see [@sec:reset-inference]).
 It cannot be connected to both a `UInt`{.firrtl} and an `AsyncReset`{.firrtl}.
 
 The `AsyncReset`{.firrtl} type can be connected to another `AsyncReset`{.firrtl} or to a `Reset`{.firrtl}.

--- a/spec.md
+++ b/spec.md
@@ -1022,7 +1022,7 @@ Nodes may only appear "on the left side" of a connect.
 Wires and registers may appear "on either side of a connect statement".
 Ports are always considered from the perspective of "inside the module".
 Moreover, input ports may only appear "on the left side" of a connect, while output ports may only appear "on the right side" of a connect.
-Finally, while submodules instances and memories are strictly sources, they interact with the sub-field rule below, allowing connections to their input ports
+Finally, while submodules instances and memories are strictly sources, they interact with the sub-field rule in such a way that their input ports are sinks.
 
 ## Type Equivalence
 

--- a/spec.md
+++ b/spec.md
@@ -217,7 +217,7 @@ An optional group may only be defined inside a module.
 An optional group must reference a group declared in the current circuit.
 An optional group forms a lexical scope (as with [@sec:conditional-scopes]) for all identifiers declared inside it---a group may use identifiers declared outside the group, but identifiers declared in the group may not be used in parent lexical scopes.
 The statements in a group are restricted in what identifiers they are allowed to drive.
-A statement in a group may drive no sinks declared outside the group _with one exception_: a statement in a group may drive reference types declared outside the group if the reference types are associated with the group in which the statement is declared (see: [@sec:reference-types]).
+A statement in a group may drive no sinks declared outside the group _with one exception_: a statement in a group may drive reference types declared outside the group if the reference types are associated with the group in which the statement is declared (see: [@sec:probe-types]).
 
 The circuit below contains one optional group declaration, `Bar`.
 Module `Foo` contains a group definition that creates a node computed from a port defined in the scope of `Foo`.
@@ -1351,7 +1351,7 @@ The reset signal must be a `Reset`{.firrtl}, `UInt<1>`{.firrtl}, or `AsyncReset`
 If the reset signal is an `AsyncReset`{.firrtl}, then the reset value must be a constant type.
 The behavior of the register depends on the type of the reset signal.
 `AsyncReset`{.firrtl} will immediately change the value of the register.
-`UInt<1>`{.firrtl} will not change the value of the register until the next positive edge of the clock signal (see [@sec:reset-type]).
+`UInt<1>`{.firrtl} will not change the value of the register until the next positive edge of the clock signal (see [@sec:reset-types]).
 `Reset`{.firrtl} is an abstract reset whose behavior depends on reset inference.
 In the following example, `myreg`{.firrtl} is assigned the value `myinit`{.firrtl} when the signal `myreset`{.firrtl} is high.
 
@@ -2005,7 +2005,7 @@ module Foo:
 
 Define statements can set a `Probe`{.firrtl} to either a `Probe`{.firrtl} or `RWProbe`{.firrtl}, but a `RWProbe`{.firrtl} cannot be set to a `Probe`{.firrtl}.
 The inner types of the two references must (recursively) be identical or identical with the destination containing uninferred versions of the corresponding element in the source type.
-See [@sec:width-and-reset-inference] for details.
+See [@sec:type-inference] for details.
 
 ### Probes and Passive Types
 

--- a/spec.md
+++ b/spec.md
@@ -703,7 +703,7 @@ module Processor :
 ```
 
 This defines a module `Processor` with a single input port `enq` which enqueues data using a ready-valid interface.
-Because `enq` is a single port, we can connect to it with a single `connect` statement (see [@sec:connections]).
+Because `enq` is a single port, we can connect to it with a single `connect`{.firrtl} statement (see [@sec:connections]).
 In the final hardware, however, while the `word` and `valid` fields point *into* the module, this port has a flipped field `ready` which points *out of* the module instead.
 
 ### Enumeration Types
@@ -753,8 +753,6 @@ However, when forcing is not needed, the `Probe`{.firrtl} allows more aggressive
 
 Probes can be passed through ports using the `define`{.firrtl} statement (see [@sec:define]).
 
-For details of how to read and write through probe types, see [@sec:reading-probe-references;@sec:force-and-release].
-
 Probe types may be specified as part of an external module (see [@sec:externally-defined-modules]), with the resolved referent for each specified using `ref`{.firrtl} statements.
 
 `Probe`{.firrtl} and `RWProbe`{.firrtl} types may be associated with an optional group (see [@sec:optional-groups]).
@@ -801,10 +799,10 @@ module Example:
 
 Stateful elements, such as registers and memories, may contain data of aggregate types.
 Registers with bundle types are especially common.
-However, when using bundle types in stateful elements, the notion of `flip` does not make sense.
+However, when using bundle types in stateful elements, the notion of `flip`{.firrtl} does not make sense.
 There is no directionality to the data inside a register; the data just *is*.
 
-A **passive type** is a type which does not make use of `flip`.
+A **passive type** is a type which does not make use of `flip`{.firrtl}.
 
 More precisely, a passive type is defined recursively:
 
@@ -812,7 +810,7 @@ More precisely, a passive type is defined recursively:
 - All probe types are passive.
 - All property types are passive.
 - A vector type is passive if and only if the element type is passive.
-- A bundle type is passive if and only if it contains no field which is marked `flip`
+- A bundle type is passive if and only if it contains no field which is marked `flip`{.firrtl}
   and the type of each field is passive.
 - An enum type is passive if and only if the type of each of its variants is passive.
 
@@ -1032,8 +1030,6 @@ Moreover, input ports may only appear "on the left side" of a connect, while out
 Finally, while submodules instances and memories are strictly sources, they interact with the sub-field rule below, allowing connections to their input ports
 
 ## Type Equivalence
-
-TODO: Replace this with a relation like "S 'coerces to' T".
 
 The type equivalence relation determines whether one values of one type can be coerced into values of another.
 

--- a/spec.md
+++ b/spec.md
@@ -980,6 +980,20 @@ connect z, asUInt(y)
 
 See [@sec:primitive-operations] for more details on casting.
 
+### Probes and Type Inference
+
+Given a `Probe<T>`{.firrtl} or `RWProbe<T>`{.firrtl}, the inner type `T`{.firrtl} may be an inferred type (see [@sec:probe-types]).
+The inner type `T`{.firrtl} will be inferred, however, they must do so in a way which does not affect the hardware.
+
+A module with a probe with an inferred inner type must resolve all other inferred types to the same uninferred types as it would if the probe were to be removed.
+
+Additionally, inference constraints may only flow in few restricted ways:
+
+- Inference constraints may flow from child to parent through its `output`{.firrtl} ports.
+- Inference constraints may flow from parent to child through its `input`{.firrtl} ports.
+- In a `define`{.firrtl} expression, only the right-hand side may impose inference constraints on the left-hand side.
+- Neither `read`{.firrtl} expressions nor `force`{.firrtl} statements may impose inference constraints.
+
 # Connections
 
 ## Flow

--- a/spec.md
+++ b/spec.md
@@ -980,40 +980,11 @@ connect z, asUInt(y)
 
 See [@sec:primitive-operations] for more details on casting.
 
-### Probes and Type Inference
-
-Probe types do participate in global width and reset inference, but only in the direction of the reference itself (no inference in the other direction, even with force statements).
-Both inner types of the references used in a `define`{.firrtl} statement must be identical or the same type with the destination uninferred (this is checked recursively).
-Additionally, any contained reset type is similarly only inferred in the direction of the reference, even if it eventually reaches a known reset type.
-
-In the following example, the FIRRTL compiler will produce an error constrasted with inferring the input port as `AsyncReset`{.firrtl} if a direct connection was used:
-
-```firrtl
-circuit :
-  public module ResetInferBad :
-    input in : Reset
-    output out : AsyncReset
-    connect out, read(probe(in))
-```
-
-The following circuit has all resets inferred to `AsyncReset`{.firrtl}, however:
-
-```firrtl
-circuit :
-  public module ResetInferGood :
-    input in : Reset
-    output out : Reset
-    output out2 : AsyncReset
-    connect out, read(probe(in))
-    connect out2, in
-```
-
-
 # Connections
 
 ## Flow
 
-The direction that signals travel across wires is determined by multiple factors: the kind of circuit component (e.g., `input` vs `output`), the side of a connect statement it appears on, and the presence of `flip`s if the signal is a bundle type.
+The direction that signals travel across wires is determined by multiple factors: the kind of circuit component (e.g., `input`{.firrtl} vs `output`{.firrtl}), the side of a connect statement it appears on, and the presence of `flip`{.firrtl}s if the signal is a bundle type.
 
 To ensure connections are meaningful when taking directionality into account, every expression in FIRRTL has a **flow**.
 The flow of an expression can be one of **source**, **sink**, or **duplex**.

--- a/spec.md
+++ b/spec.md
@@ -621,6 +621,27 @@ TODO: mention `regreset`.
 
 The reset types also have the uninferred form: `Reset`{.firrtl} (see [@sec:reset-inference]).
 
+### Analog Type
+
+The analog type specifies that a wire or port can be attached to multiple drivers.
+`Analog`{.firrtl} cannot be used as part of the type of a node or register, nor can it be used as part of the datatype of a memory.
+In this respect, it is similar to how `inout`{.firrtl} ports are used in Verilog, and FIRRTL analog signals are often used to interface with external Verilog or VHDL IP.
+
+In contrast with all other ground types, analog signals cannot appear on either side of a connection statement.
+Instead, analog signals are attached to each other with the commutative `attach`{.firrtl} statement.
+An analog signal may appear in any number of attach statements, and a legal circuit may also contain analog signals that are never attached.
+The only primitive operations that may be applied to analog signals are casts to other signal types.
+
+When an analog signal appears as a field of an aggregate type, the aggregate cannot appear in a standard connection statement.
+
+As with integer types, an analog type can represent a multi-bit signal.
+When analog signals are not given a concrete width, their widths are inferred according to a highly restrictive width inference rule, which requires that the widths of all arguments to a given attach operation be identical.
+
+``` firrtl
+Analog<1>  ; 1-bit analog type
+Analog<32> ; 32-bit analog type
+```
+
 ## Aggregate Types
 
 FIRRTL supports three aggregate types: vectors, bundles, and enumerations.
@@ -712,27 +733,6 @@ In the following example, all variants have the type `UInt<0>`{.firrtl}.
 
 ``` firrtl
 {|a, b, c|}
-```
-
-## Analog Type
-
-The analog type specifies that a wire or port can be attached to multiple drivers.
-`Analog`{.firrtl} cannot be used as part of the type of a node or register, nor can it be used as part of the datatype of a memory.
-In this respect, it is similar to how `inout`{.firrtl} ports are used in Verilog, and FIRRTL analog signals are often used to interface with external Verilog or VHDL IP.
-
-In contrast with all other ground types, analog signals cannot appear on either side of a connection statement.
-Instead, analog signals are attached to each other with the commutative `attach`{.firrtl} statement.
-An analog signal may appear in any number of attach statements, and a legal circuit may also contain analog signals that are never attached.
-The only primitive operations that may be applied to analog signals are casts to other signal types.
-
-When an analog signal appears as a field of an aggregate type, the aggregate cannot appear in a standard connection statement.
-
-As with integer types, an analog type can represent a multi-bit signal.
-When analog signals are not given a concrete width, their widths are inferred according to a highly restrictive width inference rule, which requires that the widths of all arguments to a given attach operation be identical.
-
-``` firrtl
-Analog<1>  ; 1-bit analog type
-Analog<32> ; 32-bit analog type
 ```
 
 ## Probe Types

--- a/spec.md
+++ b/spec.md
@@ -938,30 +938,32 @@ TODO: Namespaces
 
 FIRRTL has support for limited type inference.
 This comes in two flavors:
-Width inference allows an integer type's bitwidth to be left unspecified.
-Additionally, reset inference allows the use of `Reset` which will resolve to either a synchronous or asynchronous reset.
+Width inference and reset inference.
 
 ### Width Inference
-TODO: Uninferred widths
 
-For all circuit components declared with unspecified widths,
-the FIRRTL compiler will infer the minimum possible width that maintains the legality of all its incoming connections.
-If a circuit component has no incoming connections, and the width is unspecified, then an error is thrown to indicate that the width could not be inferred.
+Normally, the three integer ground types are written with explicit bit widths.
+The bit widths are given in angel brackets, such as the 8 in `UInt<8>`{.firrtl}.
+This is called the **uninferred** variant of the type.
 
-For module input ports with unspecified widths, the inferred width is the minimum possible width that maintains the legality of all incoming connections to all instantiations of the module.
-
-The width of a ground-typed multiplexer expression is the maximum of its two corresponding input widths.
-For multiplexing aggregate-typed expressions, the resulting widths of each leaf sub-element is the maximum of its corresponding two input leaf sub-element widths.
-
-The width of each primitive operation is detailed in [@sec:primitive-operations].
-
-The width of constant integer expressions is detailed in their respective sections.
+FIRRTL also supports an **inferred** variant of these types.
+They are written as follows:
 
 ```firrtl
 UInt
 SInt
 Analog
 ```
+
+When an inferred variant of an integer ground type is used, FIRRTL will calculate the minimum width needed for it.
+It is an error if the minimum size cannot be calculated.
+
+The width of a mux expression is the maximum of its two corresponding input widths.
+For multiplexing aggregate-typed expressions, the resulting widths of each leaf sub-element is the maximum of its corresponding two input leaf sub-element widths.
+TODO: Are these anywhere near complete enough to bother mentioning them? It seems better to just remove this paragraph until we have the exact rules.
+
+The width of each primitive operation is detailed in [@sec:primitive-operations].
+TODO: What "width"? The minimum widths?
 
 ### Reset Inference
 

--- a/spec.md
+++ b/spec.md
@@ -576,17 +576,17 @@ FIRRTL has four classes of types: **ground** types, **aggregate** types, **probe
 
 ## Ground Types
 
-Ground types are the most fundamental types.
-They include integer types, clocks, and resets.
+Ground types are types which are not composed of other types.
+They are the integer types, clocks, and resets.
 
 ### Integer Types
 
 FIRRTL supports both signed and unsigned integer types.
 
-`UInt<n>` is an `n`-bit wide unsigned integer.
-`SInt<n>` is an `n`-bit wide signed integer.
+`UInt<n>`{.firrtl} is an `n`-bit wide unsigned integer.
+`SInt<n>`{.firrtl} is an `n`-bit wide signed integer.
 
-```
+```firrtl
 UInt<10> ; a 10-bit unsigned integer
 SInt<32> ; 32-bit signed integer
 ```
@@ -604,7 +604,7 @@ Integer types also have the uninferred forms: `UInt`{.firrtl} and `SInt`{.firrtl
 
 Clocks require special physical considerations in hardware.
 FIRRTL defines the `Clock` type to track clocks throughout a design.
-All registers are linked to a clock (see [@sec:conditionals]).
+All registers are linked to a clock (see [@sec:registers]).
 
 TODO: Commentary on clock-crossing or multi-clock designs?
 
@@ -635,7 +635,7 @@ The following example specifies a 10-element vector of 16-bit unsigned integers.
 UInt<16>[10]
 ```
 
-Note that the element type of a vector can be any type, including another aggregate types.
+Note that the element type of a vector can be any type, including another aggregate type.
 The following example specifies a 20-element vector, each of which is a 10-element vector of 16-bit unsigned integers.
 
 TODO: *Any* type? What about probes and properties?
@@ -651,15 +651,25 @@ TODO: In analogy to 0-width integers, write a section on 0-length vecs.
 A bundle type is used to represent a collection of values.
 They can also be used to facilitate bidirectional connections between circuit components.
 
-A bundle type consists of a set of fields.
+A bundle type consists of one or more fields.
 Each field has a name and a type.
 Fields may also be flipped.
+
+TODO: Is it one or more fields? Or zero or more?
 
 The following is an example of a possible type for representing a complex number.
 It has two fields, `real`{.firrtl}, and `imag`{.firrtl}, both 10-bit signed integers.
 
 ```firrtl
 { real: SInt<10>, imag: SInt<10> }
+```
+
+The types of each field may be any type, including other aggregate types.
+
+```firrtl
+{ real: { word: UInt<32>, valid: UInt<1>, flip ready: UInt<1> },
+  imag: { word: UInt<32>, valid: UInt<1>, flip ready: UInt<1> } }
+
 ```
 
 Here is an example of a bundle with a flipped field.
@@ -681,20 +691,13 @@ This defines a module `Processor` with a single input port `enq` which enqueues 
 Because `enq` is a single port, we can connect to it with a single `connect` statement (see [@sec:connections]).
 In the final hardware, however, while the `word` and `valid` fields point *into* the module, this port has a flipped field `ready` which points *out of* the module instead.
 
-The types of each field may be any type, including other aggregate types.
-
-```firrtl
-{ real: { word: UInt<32>, valid: UInt<1>, flip ready: UInt<1> },
-  imag: { word: UInt<32>, valid: UInt<1>, flip ready: UInt<1> } }
-
-```
-
 ### Enumeration Types
 
 Enumerations are disjoint union types.
 
 Each enumeration consists of a set of variants.
-Each variant is named with a tag and each has a passive type (see [@sec:passive-types]).
+Each variant is named with a tag.
+Each variant also has a passive type associated with it (see [@sec:passive-types]).
 
 TODO: "cannot contain analog or probe types."
 
@@ -743,7 +746,7 @@ Probe types are not synthesizable.
 There are two probe types, `Probe<T>`{.firrtl} is a read-only variant and `RWProbe<T>`{.firrtl} is a read-write variant.
 In both cases, `T`{.firrtl} must be a passive type (see [@sec:passive-types]).
 
-They are created using the `probe`{.firrtl} and `rwprobe`{.firrtl} expressions (see [@sec:probes]).
+`Probe`{.firrtl} and `RWProbe`{.firrtl} are created using the `probe`{.firrtl} and `rwprobe`{.firrtl} expressions, respectively (see [@sec:probes]).
 
 Both `Probe`{.firrtl} and `RWProbe`{.firrtl} may be read from using the `read`{.firrtl} expression (see [@sec:reading-probe-references]).
 `RWProbe`{.firrtl} may also be forced using the `force`{.firrtl} and `force_initial`{.firrtl} commands (see [@sec:force-and-release]).

--- a/spec.md
+++ b/spec.md
@@ -863,7 +863,7 @@ All integer literals are `const`{.firrtl}.
 For example, `UInt<8>(42)`{.firrtl} has type `const UInt<8>`{.firrtl}.
 
 Ports can have a `const`{.firrtl} type, and thus, a module may receive constant values from its parent module.
-This may even happen in `public` modules, and so the value of a `const`{.firrtl} type need not be known statically (see TODO).
+This may even happen in `public`{.firrtl} modules, and so the value of a `const`{.firrtl} type need not be known statically (see TODO).
 
 Typically, primitive operations will result in a `const`{.firrtl} type whenever each of its inputs are `const`{.firrtl} (see prim ops TODO).
 TODO: Example?

--- a/spec.md
+++ b/spec.md
@@ -734,7 +734,6 @@ Probe types expose and provide access to circuit components contained inside a m
 Probe types are useful for testing and verification, since they allow a design to read to and write from circuit components without knowing the hierarchical path to that component in the design.
 
 There are two probe types, `Probe<T>`{.firrtl} is a read-only variant and `RWProbe<T>`{.firrtl} is a read-write variant.
-In both cases, `T`{.firrtl} must be a ground type (see [@sec:ground-types]).
 
 Examples:
 

--- a/spec.md
+++ b/spec.md
@@ -892,16 +892,6 @@ input c : const { real : SInt<8>, imag : SInt<8> }
 
 TODO: Word this more precisely.
 
-### A note on implementation
-
-Constant types are a restriction on FIRRTL types.
-Therefore, FIRRTL structures which would be expected to produce certain Verilog structures will produce the same structure if instantiated with a constant type.
-For example, an input port of type `const UInt`{.firrtl} will result in a port in the Verilog, if under the same conditions an input port of type `UInt`{.firrtl} would have.
-
-It is not intended that constants are a replacement for parameterization.
-Constant typed values have no particular meta-programming capability.
-It is, for example, expected that a module with a constant input port be fully compilable to non-parameterized Verilog.
-
 ## Type Alias
 
 A type alias is a mechanism to assign names to existing FIRRTL types.

--- a/spec.md
+++ b/spec.md
@@ -897,27 +897,41 @@ TODO: Word this more precisely.
 
 ## Type Alias
 
-A type alias is a mechanism to assign names to existing FIRRTL types.
-Type aliases enables their reuse across multiple declarations.
+Type aliases allow us to give names to types.
+This is useful for bundle types, especially when they have many fields.
+It is also useful for hinting at what the value represents.
+
+Examples:
 
 ```firrtl
 type WordType = UInt<32>
 type ValidType = UInt<1>
-type Data = { w: WordType, valid: ValidType, flip ready: UInt<1> }
+type Data = { w : WordType, valid : ValidType, flip ready : UInt<1> }
 type AnotherWordType = UInt<32>
 
 module TypeAliasMod:
-  input in: Data
-  output out: Data
-  wire w: AnotherWordType
+  input in : Data
+  output out : Data
+  wire w : AnotherWordType
   connect w, in.w
-  ...
+  ; ...
 ```
 
-The `type` declaration is globally defined and all named types exist in the same namespace and thus must all have a unique name.
+Type aliases have structural identity.
+In other words, when we compare two types, we expand all type aliases recursively until we are left with type expressions that have no aliases.
+For instance, in the above example, we can connect `in.w`{.firrtl} to `w`{.firrtl} since their types, `WordType` and `AnotherWordType` respectively, both expand to `UInt<32>`{.firrtl}.
+
+TODO: Type equivalence should mention this.
+TODO: Can type aliases be recursive? Are they in scope of each other?
+
+TODO: Mention that `type` is a top-level decl.
+TODO: How global? Global to the `circuit`?
+
+The `type`{.firrtl} declaration is globally defined and all named types exist in the same namespace and thus must all have a unique name.
 Type aliases do not share the same namespace as modules; hence it is allowed for type aliases to conflict with module names.
-Note that when we compare two types, the equivalence is determined solely by their structures.
-For instance types of `w`{.firrtl} and `in.w`{.firrtl} are equivalent in the example above even though they are different type alias.
+
+TODO: Is there a rationale for this design choice?
+TODO: Namespaces
 
 ## Type Equivalence
 

--- a/spec.md
+++ b/spec.md
@@ -873,14 +873,17 @@ An expression of type `const T`{.firrtl} is implicitly upcast to type `T`{.firrt
 
 TODO: be more precise about this?
 
-Constants may be used as the target of a connect so long as the source of the connect is itself constant.
-These rules ensure all constants are derived from constant integer expressions or from constant-typed input ports of a public module.
+Expressions with `const`{.firrtl} may be used as the target of a connect statement as long as the following hold:
+
+- the source of the connect is `const`{.firrtl}
+- the conditions of all containing `when`{.firrtl} blocks the connect statement is nested in must have conditions of type `const UInt<1>`
+- the subject of any containing `match`{.firrtl} blocks the connect statement is nested in must have a `const` type
+
+TODO: How do match statements interact?
 
 Constant types may be used in ports, wire, and nodes.
 
-
-Last-connect semantics of constant typed values are well defined, so long as any control flow is conditioned on an expression which has a constant type.
-This means if a constant is being assigned to in a `when`{.firrtl} block, the `when`{.firrtl}'s condition must be a constant.
+TODO: What are disallowed in?
 
 References to a subcomponent of a circuit component with a `const`{.firrtl} vector or bundle type results in a `const`{.firrtl} of the inner type.
 For example:

--- a/spec.md
+++ b/spec.md
@@ -672,11 +672,9 @@ TODO: In analogy to 0-width integers, write a section on 0-length vecs.
 A bundle type is used to represent a collection of values.
 They can also be used to facilitate bidirectional connections between circuit components.
 
-A bundle type consists of one or more fields.
+A bundle type consists of zero or more fields.
 Each field has a name and a type.
 Fields may also be flipped.
-
-TODO: Is it one or more fields? Or zero or more?
 
 The following is an example of a possible type for representing a complex number.
 It has two fields, `real`{.firrtl}, and `imag`{.firrtl}, both 10-bit signed integers.
@@ -741,10 +739,10 @@ Probe types expose and provide access to circuit components contained inside a m
 
 Probe types are useful for testing and verification, since they allow a design to read to and write from circuit components without knowing the hierarchical path to that component in the design.
 
-Probe types are not synthesizable.
-
 There are two probe types, `Probe<T>`{.firrtl} is a read-only variant and `RWProbe<T>`{.firrtl} is a read-write variant.
-In both cases, `T`{.firrtl} must be a passive type (see [@sec:passive-types]).
+In both cases, `T`{.firrtl} must be a ground type (see [@sec:ground-types]).
+
+TODO: Verify this restriction on `T`.
 
 `Probe`{.firrtl} and `RWProbe`{.firrtl} are created using the `probe`{.firrtl} and `rwprobe`{.firrtl} expressions, respectively (see [@sec:probes]).
 
@@ -794,6 +792,10 @@ Probe types may be specified as part of an external module (see [@sec:externally
 Probe types may target `const`{.firrtl} signals, but cannot use `rwprobe`{.firrtl} with a constant signal to produce a `RWProbe<const T>`{.firrtl}.
 
 TODO: What's a signal?
+
+Probe types are not synthesizable.
+
+TODO: What does this mean technically?
 
 ## Property Types
 

--- a/spec.md
+++ b/spec.md
@@ -729,9 +729,10 @@ In the following example, all variants have the type `UInt<0>`{.firrtl}.
 
 ## Probe Types
 
-Probe types expose and provide access to circuit components contained inside a module.
-
-Probe types are useful for testing and verification, since they allow a design to read to and write from circuit components without knowing the hierarchical path to that component in the design.
+Probe types expose and provide access to circuit components contained inside a module for use
+They are intended for verification.
+Ports with a probe type do not necessarily result in physical hardware.
+Special verification constructs enable the value of a probe to be read or forced remotely.
 
 There are two probe types, `Probe<T>`{.firrtl} is a read-only variant and `RWProbe<T>`{.firrtl} is a read-write variant.
 

--- a/spec.md
+++ b/spec.md
@@ -1012,7 +1012,7 @@ Finally, while submodules instances and memories are strictly sources, they inte
 
 ## Type Equivalence
 
-The type equivalence relation determines whether one values of one type can be coerced into values of another.
+The type equivalence relation is used to determine whether a connection between two components is legal.
 
 An unsigned integer type is always equivalent to another unsigned integer type regardless of bit width, and is not equivalent to any other type.
 Similarly, a signed integer type is always equivalent to another signed integer type regardless of bit width, and is not equivalent to any other type.

--- a/spec.md
+++ b/spec.md
@@ -712,9 +712,7 @@ Enumerations are disjoint union types.
 
 Each enumeration consists of a set of variants.
 Each variant is named with a tag.
-Each variant also has a passive type associated with it (see [@sec:passive-types]).
-
-TODO: "cannot contain analog or probe types."
+Each variant also has a type associated with it which must be connectable (see [@sec:connectable-types]) and passive (see [@sec:passive-types]).
 
 In the following example, the first variant has the tag `a`{.firrtl} with type `UInt<8>`{.firrtl}, and the second variant has the tag `b`{.firrtl} with type `UInt<16>`{.firrtl}.
 
@@ -795,6 +793,18 @@ module Example:
   input intProp : Integer ; an input port of Integer property type
 ```
 
+## Connectable Types
+
+A **connectable type** is one which may be the type of expressions which may participate in the `connect`{.firrtl} statement.
+
+A connectable type is defined recursively:
+
+- unsigned integers,
+- signed integers,
+- a vector type where the element type is a connectable type,
+- bundles where each field type is a connectable type, or
+- an enumeration type
+
 ## Passive Types
 
 Stateful elements, such as registers and memories, may contain data of aggregate types.
@@ -812,7 +822,7 @@ More precisely, a passive type is defined recursively:
 - A vector type is passive if and only if the element type is passive.
 - A bundle type is passive if and only if it contains no field which is marked `flip`{.firrtl}
   and the type of each field is passive.
-- An enum type is passive if and only if the type of each of its variants is passive.
+- All enumeration types are passive.
 
 Registers and memories may only be parametrized over passive types.
 

--- a/spec.md
+++ b/spec.md
@@ -876,8 +876,8 @@ TODO: be more precise about this?
 Expressions with `const`{.firrtl} may be used as the target of a connect statement as long as the following hold:
 
 - the source of the connect is `const`{.firrtl}
-- the conditions of all containing `when`{.firrtl} blocks the connect statement is nested in must have conditions of type `const UInt<1>`
-- the subject of any containing `match`{.firrtl} blocks the connect statement is nested in must have a `const` type
+- the conditions of all containing `when`{.firrtl} blocks the connect statement is nested in must have conditions of type `const UInt<1>`{.firrtl}
+- the subject of any containing `match`{.firrtl} blocks the connect statement is nested in must have a `const`{.firrtl} type
 
 TODO: How do match statements interact?
 

--- a/spec.md
+++ b/spec.md
@@ -603,8 +603,6 @@ Clocks require special physical considerations in hardware.
 FIRRTL defines the `Clock`{.firrtl} type to track clocks throughout a design.
 All registers are linked to a clock (see [@sec:registers]).
 
-TODO: Commentary on clock-crossing or multi-clock designs?
-
 ### Reset Types
 
 Once a circuit is powered on, it may require an explicit reset in order to put it into a known state.
@@ -614,9 +612,9 @@ In FIRRTL, we have the option of using both synchronous or asynchronous resets.
 The synchronous reset type is simply a 1-bit unsigned integer: `UInt<1>`{.firrtl}.
 The asynchronous reset type is `AsyncReset`{.firrtl}.
 
-TODO: mention `regreset`.
+Registers may be declared linked to a reset (see [@sec:registers-with-reset]).
 
-The reset types also have the uninferred form: `Reset`{.firrtl} (see [@sec:reset-inference]).
+The reset types also have the inferred form: `Reset`{.firrtl} (see [@sec:reset-inference]).
 
 ### Analog Type
 
@@ -639,7 +637,7 @@ Analog<1>  ; 1-bit analog type
 Analog<32> ; 32-bit analog type
 ```
 
-TODO: There is an inferred form see TODO.
+The analog type also has the inferred form: `Analog`{.firrtl} (see [@sec:width-inference]).
 
 ## Aggregate Types
 
@@ -744,8 +742,8 @@ TODO: Verify this restriction on `T`.
 Examples:
 
 ```firrtl
-Probe<UInt<8>>                         ; readable probe to an 8-bit unsigned integer
-RWProbe<{ x : UInt<1>, y : UInt<1> }>  ; read-writable probe to bundle
+Probe<UInt<8>>
+RWProbe<UInt<8>>
 ```
 
 `Probe`{.firrtl} and `RWProbe`{.firrtl} are created using the `probe`{.firrtl} and `rwprobe`{.firrtl} expressions, respectively (see [@sec:probes]).
@@ -763,36 +761,11 @@ TODO: exaplain groups `Probe<UInt, A.B>`{.firrtl}
 
 For details of how to read and write through probe types, see [@sec:reading-probe-references;@sec:force-and-release].
 
-Sub-accesses are not allowed with types where the result is or has probe types within.
-This is because sub-accesses are essentially conditional connections (see [@sec:sub-accesses] for details), which are not allowed with probe types.
-
-TODO: What does this mean?
-
-The following example demonstrates some legal and illegal expressions:
-
-```firrtl
-module NoSubAccessesWithProbes :
-  input x : { a : Probe<UInt[2]>, b : UInt }[3]
-  input i : UInt
-  input c : const UInt
-  output p : Probe<UInt>
-
-  ; Illegal: x[i], x[c]
-  ; Illegal: x[0].a[i], x[0].a[c]
-
-  ; Legal:
-  define p = x[0].a[1]
-```
-
 Probe types may be specified as part of an external module (see [@sec:externally-defined-modules]), with the resolved referent for each specified using `ref`{.firrtl} statements.
 
 Probe types may target `const`{.firrtl} signals, but cannot use `rwprobe`{.firrtl} with a constant signal to produce a `RWProbe<const T>`{.firrtl}.
 
 TODO: What's a signal?
-
-Probe types are not synthesizable.
-
-TODO: What does this mean technically?
 
 ## Property Types
 

--- a/spec.md
+++ b/spec.md
@@ -846,28 +846,51 @@ Registers and memories may only be parametrized over passive types.
 
 ## Constant Types
 
-A constant type is a type whose value is guaranteed to be unchanging at circuit execution time.
-Constant is a constraint on the mutability of the value, it does not imply a literal value at a point in the emitted design.
-Constant types may be used in ports, wire, and nodes.
-Operations on constant type are well defined.
-With any exception listed in the definition for such operations as have exceptions, an operation whose arguments are constant produces a constant.
-An operation with some non-constant arguments produce a non-constant.
-Constants may be used as the target of a connect so long as the source of the connect is itself constant.
-These rules ensure all constants are derived from constant integer expressions or from constant-typed input ports of a public module.
+For certain situations, it is useful to guarantee that a signal holds a value that doesn't change during simulation.
+For example, when a register has a reset, the reset value is required to be held constant (see [@sec:registers-with-reset]).
+
+Ground types and aggregate types maybe marked as constant using the `const`{.firrtl} modifier.
+
+For example:
 
 ```firrtl
 const UInt<3>
-const SInt
-const { real: UInt<32>, imag : UInt<32>, other : const SInt }
+const SInt<8>[4]
+const { real: UInt<32>, imag : UInt<32> }
 ```
+
+All integer literals are `const`{.firrtl}.
+For example, `UInt<8>(42)`{.firrtl} has type `const UInt<8>`{.firrtl}.
+
+Ports can have a `const`{.firrtl} type, and thus, a module may receive constant values from its parent module.
+This may even happen in `public` modules, and so the value of a `const`{.firrtl} type need not be known statically (see TODO).
+
+Typically, primitive operations will result in a `const`{.firrtl} type whenever each of its inputs are `const`{.firrtl} (see prim ops TODO).
+TODO: Example?
+The resulting type of a mux expression, `mux(s, a, b)`{.firrtl}, will be `const`{.firrtl} if all of `s`{.firrtl}, `a`{.firrtl}, and `b`{.firrtl} are `const`{.firrtl} (see TODO).
+
+An expression of type `const T`{.firrtl} is implicitly upcast to type `T`{.firrtl} whenever it would be required to make a primitive operation, mux expression, or connect statement typecheck.
+
+TODO: be more precise about this?
+
+Constants may be used as the target of a connect so long as the source of the connect is itself constant.
+These rules ensure all constants are derived from constant integer expressions or from constant-typed input ports of a public module.
+
+Constant types may be used in ports, wire, and nodes.
+
 
 Last-connect semantics of constant typed values are well defined, so long as any control flow is conditioned on an expression which has a constant type.
 This means if a constant is being assigned to in a `when`{.firrtl} block, the `when`{.firrtl}'s condition must be a constant.
 
-Output ports of external modules and input ports to a public module may be constant.
-In such case, the value of the port is not known, but that it is non-mutating at runtime is known.
+References to a subcomponent of a circuit component with a `const`{.firrtl} vector or bundle type results in a `const`{.firrtl} of the inner type.
+For example:
 
-The indexing of a constant aggregate produces a constant of the appropriate type for the element.
+```firrtl
+input c : const { real : SInt<8>, imag : SInt<8> }
+; c.real has type const SInt<8>
+```
+
+TODO: Word this more precisely.
 
 ### A note on implementation
 

--- a/spec.md
+++ b/spec.md
@@ -588,22 +588,19 @@ FIRRTL supports both signed and unsigned integer types.
 
 ```firrtl
 UInt<10> ; a 10-bit unsigned integer
-SInt<32> ; 32-bit signed integer
+SInt<32> ; a 32-bit signed integer
 ```
 
 Both `UInt<0>`{.firrtl} and `SInt<0>`{.firrtl} are valid types.
 They are considered to have only a single value representing zero (written as either `UInt<0>(0)`{.firrtl} or `SInt<0>(0)`{.firrtl}).
 They behave like zero when they are extended to a positive width integer type.
 
-TODO: Talk about how zero-bit integers are lowered. And how they can be stripped out.
-TODO: There was an example here:
-
-Integer types also have the uninferred forms: `UInt`{.firrtl} and `SInt`{.firrtl} (see [@sec:width-inference]).
+Integer types also have the inferred forms: `UInt`{.firrtl} and `SInt`{.firrtl} (see [@sec:width-inference]).
 
 ### Clock Type
 
 Clocks require special physical considerations in hardware.
-FIRRTL defines the `Clock` type to track clocks throughout a design.
+FIRRTL defines the `Clock`{.firrtl} type to track clocks throughout a design.
 All registers are linked to a clock (see [@sec:registers]).
 
 TODO: Commentary on clock-crossing or multi-clock designs?
@@ -642,6 +639,8 @@ Analog<1>  ; 1-bit analog type
 Analog<32> ; 32-bit analog type
 ```
 
+TODO: There is an inferred form see TODO.
+
 ## Aggregate Types
 
 FIRRTL supports three aggregate types: vectors, bundles, and enumerations.
@@ -658,8 +657,6 @@ UInt<16>[10]
 
 Note that the element type of a vector can be any type, including another aggregate type.
 The following example specifies a 20-element vector, each of which is a 10-element vector of 16-bit unsigned integers.
-
-TODO: *Any* type? What about probes and properties?
 
 ```firrtl
 UInt<16>[10][20]
@@ -680,14 +677,14 @@ The following is an example of a possible type for representing a complex number
 It has two fields, `real`{.firrtl}, and `imag`{.firrtl}, both 10-bit signed integers.
 
 ```firrtl
-{ real: SInt<10>, imag: SInt<10> }
+{ real : SInt<10>, imag : SInt<10> }
 ```
 
 The types of each field may be any type, including other aggregate types.
 
 ```firrtl
-{ real: { word: UInt<32>, valid: UInt<1>, flip ready: UInt<1> },
-  imag: { word: UInt<32>, valid: UInt<1>, flip ready: UInt<1> } }
+{ real : { word : UInt<32>, valid : UInt<1>, flip ready : UInt<1> },
+  imag : { word : UInt<32>, valid : UInt<1>, flip ready : UInt<1> } }
 
 ```
 
@@ -695,14 +692,14 @@ Here is an example of a bundle with a flipped field.
 Because the `ready` field is marked with the keyword `flip`, it will indicate the flow will be opposite of the `word` and `valid` fields.
 
 ```firrtl
-{ word: UInt<32>, valid: UInt<1>, flip ready: UInt<1> }
+{ word : UInt<32>, valid : UInt<1>, flip ready : UInt<1> }
 ```
 
-As an example of how `flip` works in context, consider a module declared like this:
+As an example of how `flip`{.firrtl} works in context, consider a module declared like this:
 
 ```firrtl
 module Processor :
-  input enq: { word: UInt<32>, valid: UInt<1>, flip ready: UInt<1> }
+  input enq : { word : UInt<32>, valid : UInt<1>, flip ready : UInt<1> }
   ; ...
 ```
 
@@ -744,25 +741,25 @@ In both cases, `T`{.firrtl} must be a ground type (see [@sec:ground-types]).
 
 TODO: Verify this restriction on `T`.
 
+Examples:
+
+```firrtl
+Probe<UInt<8>>                         ; readable probe to an 8-bit unsigned integer
+RWProbe<{ x : UInt<1>, y : UInt<1> }>  ; read-writable probe to bundle
+```
+
 `Probe`{.firrtl} and `RWProbe`{.firrtl} are created using the `probe`{.firrtl} and `rwprobe`{.firrtl} expressions, respectively (see [@sec:probes]).
 
 Both `Probe`{.firrtl} and `RWProbe`{.firrtl} may be read from using the `read`{.firrtl} expression (see [@sec:reading-probe-references]).
 `RWProbe`{.firrtl} may also be forced using the `force`{.firrtl} and `force_initial`{.firrtl} commands (see [@sec:force-and-release]).
 However, when forcing is not needed, the `Probe`{.firrtl} allows more aggressive optimization.
 
-Probe references must always be able to be statically traced to their target, or to an external module's output reference.
+TODO: Probe references must always be able to be statically traced to their target or to an external module's output reference.
 Reference-type ports are statically routed through the design using the `define`{.firrtl} statement.
-
-A reference type may be associated with an optional group (see [@sec:optional-groups]).
+TODO: A reference type may be associated with an optional group (see [@sec:optional-groups]).
 When associated with an optional group, the reference type may only be driven from that optional group.
 
-Examples:
-
-```firrtl
-Probe<UInt<8>>                         ; readable probe to an 8-bit unsigned integer
-RWProbe<{ x : UInt<1>, y : UInt<1> }>  ; read-writable probe to bundle
-Probe<UInt, A.B>                       ; readable probe associated with group A.B
-```
+TODO: exaplain groups `Probe<UInt, A.B>`{.firrtl}
 
 For details of how to read and write through probe types, see [@sec:reading-probe-references;@sec:force-and-release].
 


### PR DESCRIPTION
This PR is a moderate rewrite of the entire Types section.

This is best reviewed by building the PDF and reviewing paragraph by paragraph.

Here are some highlights:

- Uninferred types are mentioned in their own section. (Both width and reset inference).
- The section on zero-width integers is abbreviated. (It warrants mention, but doesn't need so much ink spilled)
- Analog type is scooched down.
- Small code formatting of FIRRTL (eg, spaces between braces in bundle types)
- Reword section on flips with bundle types.
- Rename "Reference Types" to "Probe Types"
- Move several examples of FIRRTL programs using probes out of the Probe Types section and into the probes section.