### PR TITLE
[nfc] Make block quotations commentary-like

### DIFF
--- a/include/spec-template.tex
+++ b/include/spec-template.tex
@@ -478,6 +478,22 @@ $if(csquotes)$
 \usepackage{csquotes}
 $endif$
 
+%% Pandoc will generate block quotes like the following:
+%%
+%%     > Hello world!
+%%
+%% Using the following LaTeX:
+%%
+%%     \begin{quote}
+%%     Hello world!
+%%     \end{quote}
+%%
+%% The default LaTeX formatting for this is to simply indent the text.
+%% Override the "quote" environment to provide something more distinctive.
+\renewenvironment{quote}
+  {\list{}{\leftmargin=2em\rightmargin=2em}\item[]\rule{\linewidth}{1pt}\it}
+  {\endlist}
+
 \begin{document}
 $if(has-frontmatter)$
 \frontmatter


### PR DESCRIPTION
Modify the LaTeX template to make the "quote" environment more like commentaries/asides.  This is modeled after how the RISC-V Specification does commentary with an indented, italicized region with a "\rule" at the top.

#### Example

With the following diff:

```diff
diff --git a/abi.md b/abi.md
index 2ab8853..a4042c8 100644
--- a/abi.md
+++ b/abi.md
@@ -3,6 +3,26 @@
 FIRRTL defines a language/IR for describing synchronous hardware circuits.
 This document specifies the mapping of FIRRTL constructs to Verilog in a manner similar to an application binary interface (ABI) which enables predictability of the output of key constructs necessary for the interoperability between circuits described in FIRRTL and between other languages and FIRRTL output.
 
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+> Thanks for reading the document.
+
+
+
 This document describes multiple versions of the ABI, specifically calling specific changes in later versions.
 It is expected that a conforming FIRRTL compiler can lower to all specified ABIs.
 This mechanism exists to allow improved representations when using tools which have better Verilog support and allow incremental migration of existing development flows to the significant representational changes introduced by ABI changes.
```

The following is produced:

<img width="503" alt="Screenshot 2023-11-09 at 16 47 15" src="https://github.com/chipsalliance/firrtl-spec/assets/1018530/d1c8f66d-fd90-4e48-ab9a-473fa58ca57c">

For comparison, the RISC-V spec does things like:
<img width="633" alt="Screenshot 2023-11-09 at 16 47 29" src="https://github.com/chipsalliance/firrtl-spec/assets/1018530/f608b031-5f4a-46ba-9ad3-a820e278f25f">
