### PR TITLE
[patch] Allow multiple group defs with same decl

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -215,7 +215,7 @@ The FIRRTL ABI specification defines supported lowering convention.  One such st
 The `group`{.firrtl} keyword defines optional functionality inside a module.
 An optional group may only be defined inside a module.
 An optional group must reference a group declared in the current circuit.
-Declarations of identifiers and references to existing identifiers following the same lexical scoping rules as FIRRTL conditional statements (see: [@sec:conditional-scopes])---identifiers declared in the group definition may not be used outside the group while groups may refer to identifiers declared outside the group.
+An optional group forms a lexical scope (as with [@sec:conditional-scopes]) for all identifiers declared inside it---a group may use identifiers declared outside the group, but identifiers declared in the group may not be used in parent lexical scopes.
 The statements in a group are restricted in what identifiers they are allowed to drive.
 A statement in a group may drive no sinks declared outside the group _with one exception_: a statement in a group may drive reference types declared outside the group if the reference types are associated with the group in which the statement is declared (see: [@sec:reference-types]).
 

--- a/spec.md
+++ b/spec.md
@@ -233,6 +233,26 @@ circuit:
       node notA = not(a)
 ```
 
+Multiple optional group definitions may reference the same group declaration.
+Each optional group definition is a new lexical scope even if they reference the same declaration.
+The circuit below shows module `Foo` having two group definitions both referencing group declaration `Bar`.
+The first group definition may not reference node `c`.
+The second group definition may not reference node `b`.
+
+``` firrtl
+circuit:
+  declgroup Bar, bind:
+
+  module Foo:
+    input a: UInt<1>
+
+    group Bar: ; First group definition
+      node b = a
+
+    group Bar: ; Second group definition
+      node c = a
+```
+
 Optional group declarations may be nested.
 Optional group declarations are declared with the `declgroup`{.firrtl} keyword indented under an existing `declgroup`{.firrtl} keyword.
 The circuit below contains four optional group declarations, three of which are nested.


### PR DESCRIPTION
Add language to the spec that allows multiple group definitions in the same module to reference the same group declaration.

This is done as it is more straightforward to have Chisel create groups whenever a module's constructor runs as opposed to waiting until the module is "closed" before creating a group.  Modules may have arbitrarily complex levels of inheritance and there's no great reason to force Chisel to have to combine groups itself.  This also forces Chisel users of groups to not treat groups as arbitrary scope escape hatches where anything defined in a group is visible to anything in a later declared group.  This better matches Chisel's scoping rules where it tries to align with Scala scoping rules.

This change does not disallow _merging groups_ in a FIRRTL compiler.  This is support that will be added to CIRCT [1].  The ABI is intentionally silent about how this situation should be lowered as the modules that are created to implement the logic of a group are an implementation detail. E.g., in the code example in this commit, it is legal to either create two modules that will be bound in or one module that will be bound in which combines the two group definitions.

[1]: https://github.com/llvm/circt/issues/6228