### PR TITLE
[major] Rename groups to layers

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -6,7 +6,7 @@
       <item>module</item>
       <item>extmodule</item>
       <item>intmodule</item>
-      <item>declgroup</item>
+      <item>layer</item>
     </list>
     <list name="keywords">
       <item>input</item>
@@ -16,7 +16,7 @@
       <item>parameter</item>
       <item>skip</item>
       <item>inst</item>
-      <item>group</item>
+      <item>layerblock</item>
       <item>of</item>
       <item>wire</item>
       <item>node</item>


### PR DESCRIPTION
Change optional groups to "layers".  This much better captures the underlying concept as well as the possibility of nesting.  Change `declgroup` to `layer`. Change `group` to `layerblock`.

I recognize this is a pretty disruptive change. However, being able to explain this with the correct terms is highly beneficial. I always had difficulty talking about "nested optional groups" while "nested layers" makes more sense. I'm trying to draw analogies to layers in graphic design or existing [software engineering concepts](https://en.wikipedia.org/wiki/Layer_(object-oriented_design)).

This also inverts the focus in a good way. Layers are really about a collection of optional functionality in "layer blocks" that exists across disparate modules. The previous description incorrectly inverted this: the "groups"/"layers" were inside the module and the "groupdecl" was outside. h/t @mmaloney-sf for pointing this out.

I do want to get feedback on this, specifically from @mmaloney-sf, @mwachs5, and @darthscsi.