### PR TITLE
[major] Define option groups and instance choices

### DIFF
--- a/abi.md
+++ b/abi.md
@@ -316,7 +316,7 @@ I.e., the end user may safely include none, either, or both of the bindings file
 A target will result in the creation of specialization files.
 One specialization file per public module per option for a given target will be created.
 
-Including a specialization file in the elaboration of Verilog produced by a FIRRTL compiler specializes the instantiation hierarchy of a public module with that option.
+Including a specialization file in the elaboration of Verilog produced by a FIRRTL compiler specializes the instantiation hierarchy under the associated public module with that option.
 
 Each specialization file must have the following filename where `module` is the name of the public module, `target` is the name of the target, and `option` is the name of the option:
 

--- a/abi.md
+++ b/abi.md
@@ -321,7 +321,7 @@ Including a specialization file in the elaboration of Verilog produced by a FIRR
 Each specialization file must have the following filename where `module` is the name of the public module, `target` is the name of the target, and `option` is the name of the option:
 
 ``` ebnf
-filename = "targets_" , module , "_" , target , "_", option , ".sv" ;
+filename = "targets_" , module , "_" , target , "_", option , ".vh" ;
 ```
 
 Each specialization file will guard for multiple inclusion.
@@ -367,8 +367,8 @@ circuit Foo:
 
 To align with the ABI, this must produce the following files to specialize the circuit for option `A` or option `B`, respectively:
 
-- `targets_Foo_Target_A.sv`
-- `targets_Foo_Target_B.sv`
+- `targets_Foo_Target_A.vh`
+- `targets_Foo_Target_B.vh`
 
 What follows describes a possible implementation that aligns with the ABI.
 Note that the internal details are not part of the ABI.
@@ -399,7 +399,7 @@ endmodule
 The contents of the two option enabling files are shown below:
 
 ``` systemverilog
-// Contents of "targets_Target_A.sv"
+// Contents of "targets_Target_A.vh"
 `ifdef __target_Target_foo_x
  `ERROR__target_Target_foo_x__must__not__be__set
 `else
@@ -414,7 +414,7 @@ The contents of the two option enabling files are shown below:
 ```
 
 ``` systemverilog
-// Contents of "targets_Target_B.sv"
+// Contents of "targets_Target_B.vh"
 `ifdef __target_Target_foo_x
   `ERROR__target_Target_foo_x__must__not__be__set
 `endif
@@ -434,12 +434,12 @@ Additionally, probe on public module `Foo` requires that the following file is p
 ```
 
 If neither of the option enabling files are included, then `Bar` will by default be instantiated.
-If `targets_Foo_Target_A.sv` is included before elaboration of `Foo`, then `Baz` will be instantiated.
-If `targets_Foo_Target_B.sv` is included before elaboration of `Foo`, then `Bar` will be instantiated.
-If both `targets_Foo_Target_A.sv` and `targets_Foo_Target_B.sv` are included, then an error (by means of an undefined macro error) will be produced.
-If either `targets_Foo_Target_A.sv` or `targets_Foo_Target_B.sv` are included after `Foo` is elaborated, then an error will be produced.
+If `targets_Foo_Target_A.vh` is included before elaboration of `Foo`, then `Baz` will be instantiated.
+If `targets_Foo_Target_B.vh` is included before elaboration of `Foo`, then `Bar` will be instantiated.
+If both `targets_Foo_Target_A.vh` and `targets_Foo_Target_B.vh` are included, then an error (by means of an undefined macro error) will be produced.
+If either `targets_Foo_Target_A.vh` or `targets_Foo_Target_B.vh` are included after `Foo` is elaborated, then an error will be produced.
 
-If `ref_Foo.sv` is included before either `targets_Foo_Target_A.sv` or `targets_Foo_Target_B.sv`, then an error will be produced.
+If `ref_Foo.vh` is included before either `targets_Foo_Target_A.vh` or `targets_Foo_Target_B.vh`, then an error will be produced.
 
 ## On Types
 

--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -7,6 +7,7 @@
       <item>extmodule</item>
       <item>intmodule</item>
       <item>layer</item>
+      <item>option</item>
     </list>
     <list name="keywords">
       <item>input</item>
@@ -27,6 +28,8 @@
       <item>propassign</item>
       <item>public</item>
       <item>enablelayer</item>
+      <item>instchoice</item>
+      <item>case</item>
     </list>
     <list name="types">
       <item>UInt</item>

--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -7,7 +7,7 @@
       <item>extmodule</item>
       <item>intmodule</item>
       <item>layer</item>
-      <item>option</item>
+      <item>target</item>
     </list>
     <list name="keywords">
       <item>input</item>
@@ -29,7 +29,7 @@
       <item>public</item>
       <item>enablelayer</item>
       <item>instchoice</item>
-      <item>case</item>
+      <item>option</item>
     </list>
     <list name="types">
       <item>UInt</item>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -26,12 +26,14 @@ revisionHistory:
       - Main module must be public.
       - Make commas mandatory, not whitespace.
       - Update intrinsic module example to use a real intrinsic.
+      - Add instance choice.
     abi:
       - Add ABI for public modules and filelist output.
       - Changed ABI for group and ref generated files.
         These now use the public module and not the circuit.
       - Use EBNF to describe probe port macros and filename.
       - Correct mistakes in code examples.
+      - Add instance choice.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 3.2.0

--- a/spec.md
+++ b/spec.md
@@ -326,8 +326,8 @@ Specialization can occur either in the compiler or it can be materialized in the
 For details, consult the FIRRTL ABI specification.
 Specialization is not mandatory: options can be left unspecified, resorting to explicitly-defined default behaviour.
 
-A target may be delcared using the `target`{.firrtl} keyword.
-The availble options for which a target may take are listed using the `option`{.firrtl} keyword.
+A target may be declared using the `target`{.firrtl} keyword.
+The available options for which a target may take are listed using the `option`{.firrtl} keyword.
 An example FIRRTL circuit showing two targets, `Platform` and `Performance`, and their allowable options is shown below:
 
 ``` firrtl
@@ -534,7 +534,7 @@ By default, it will instantiate `DefaultClockGate` and when `Platform` is `FPGA`
 
 ``` firrtl
 circuit:
-  targe Platform:
+  target Platform:
     option FPGA
     option ASIC
 
@@ -4203,7 +4203,7 @@ decl =
   | decl_extmodule
   | decl_intmodule
   | decl_layer
-  | decl_option
+  | decl_target
   | decl_type_alias ;
 
 decl_module =
@@ -4232,9 +4232,9 @@ decl_layer =
     { decl_layer , newline } ,
   dedent ;
 
-decl_option =
-  "option" , id , ":" , [info] , newline, indent ,
-    { "case" , id , ":" , [ info ] , newline } ,
+decl_target =
+  "target" , id , ":" , [info] , newline, indent ,
+    { "option" , id , ":" , [ info ] , newline } ,
   dedent ;
 
 decl_type_alias = "type", id, "=", type ;

--- a/spec.md
+++ b/spec.md
@@ -152,32 +152,6 @@ Private modules have none of the restrictions of public modules.
 Private modules have no stable, defined interface and may not be used outside the current circuit.
 A private module may not be physically present in a compiled circuit.
 
-## Option Groups
-
-The option group mechanism declares configurable parameters with a pre-defined set of values to enable the specialization of designs during or after lowering.
-Options groups address the need for configurability.
-For example, designs may need to behave differently on ASIC and FPGA platforms, but at the time of FIRRTL elaboration it is not known which platform the design will be used on.
-This feature allows such choices to be expressed and embedded into the design.
-
-The `option`{.firrtl} keyword declares an option group, which contains `case`{.firrtl} declarations naming the settings allotted to that option.
-The circuit can be specialized for a single case of a given option at any time.
-Multiple option groups can be declared to capture orthogonal dimensions of configuration.
-
-Specialization can occur either in the compiler or it can be materialized in the lowering.
-For details, consult the FIRRTL ABI specification.
-Specialization is not mandatory: options can be left unspecified, resorting to explicitly-defined default behaviour.
-
-``` firrtl
-circuit:
-  option Platform:
-    case FPGA:
-    case ASIC:
-
-  option Performance:
-    case Slow:
-    case Fast
-```
-
 ## Externally Defined Modules
 
 Externally defined modules are modules whose implementation is not provided in the current circuit.
@@ -331,6 +305,40 @@ FIRRTL version 4.0.0
 circuit Foo :
   layer A, bind :
   public module Foo enablelayer A :
+```
+
+## Targets
+
+A `target`{.firrtl} describes one way that a FIRRTL circuit may be specialized for a certain use case.
+Here, specialization means choosing a specific option for a target.
+
+It is often desirable to have one FIRRTL circuit that has different logic when simulated, synthesized and mapped to a field-programmable gate array (FPGA), or synthesized to a given process technology and standard cell library.
+While this per-target customizability can be expressed and specialized in a frontend language that produces FIRRTL, it is often desirable to expose the target specialization in the FIRRTL.
+By delaying the specialization, the specialization can either be done by a FIRRTL compiler or exposed in the artifacts of a FIRRTL compiler for specialization by the consumer.
+
+Practically, targets describe a limited form of parameterization and, if not specialized by a FIRRTL compiler, allow for FIRRTL compilers to generate parametric artifacts (e.g., parametric Verilog).
+
+The `option`{.firrtl} keyword declares an option group, which contains `case`{.firrtl} declarations naming the settings allotted to that option.
+The circuit can be specialized for a single case of a given option at any time.
+Multiple option groups can be declared to capture orthogonal dimensions of configuration.
+
+Specialization can occur either in the compiler or it can be materialized in the lowering.
+For details, consult the FIRRTL ABI specification.
+Specialization is not mandatory: options can be left unspecified, resorting to explicitly-defined default behaviour.
+
+A target may be delcared using the `target`{.firrtl} keyword.
+The availble options for which a target may take are listed using the `option`{.firrtl} keyword.
+An example FIRRTL circuit showing two targets, `Platform` and `Performance`, and their allowable options is shown below:
+
+``` firrtl
+circuit:
+  target Platform:
+    option FPGA
+    option ASIC
+
+  target Performance:
+    option Slow
+    option Fast
 ```
 
 # Circuit Components
@@ -507,35 +515,46 @@ circuit Foo:
     ;; snippetend
 ```
 
-#### Instance Choices
+#### Instance Choice
 
-FIRRTL supports the specialization of designs through the `instchoice`{.firrtl} declaration, which selects the instantiated module based on an `option`{.firrtl}.
+An instance choice is a submodule instance where the choice of submodule is conditioned based on the value of a `target`{.firrtl}.
+This enables per-instance specialization for different targets.
+Additionally, this is a mechanism for module replacement.
 
-Example:
+An instance choice declaration specifies the instance name and names the option group based on which the choices are selected.
+A default module must be provided.
+The default module is instantiated by the instance choice when an option for its associated target is not specified.
+Subsequently, modules can be specified for the known choices of the selected option group.
+An instance choice does not need to specify modules for all cases.
+The instantiated modules must be either modules or external modules.
+
+An example of an instance choice is shown below.
+This instance choice is conditioned on the `Platform` target.
+By default, it will instantiate `DefaultClockGate` and when `Platform` is `FPGA` it will instantiate `FPGAClockGate`.
 
 ``` firrtl
 circuit:
-  option Platform:
-    case FPGA:
-    case ASIC:
+  targe Platform:
+    option FPGA
+    option ASIC
+
+  module DefaultClockGate:
+    input clock_in: Clock
+    output clock_out: Clock
+    input enable: UInt<1>
+
+  extmodule FPGAClockGate:
+    input clock_in: Clock
+    output clock_out: Clock
+    input enable: UInt<1>
 
   module InstanceChoice:
-    instchoice clock_gate of DefaultTarget, Platform:
-      FPGA => FPGATarget
-
-  module DefaultTarget:
-
-  module FPGATarget:
+    instchoice clock_gate of DefaultClockGate, Platform:
+      FPGA => FPGAClockGate
 ```
 
-The instance choice declaration specifies the instance name and names the option group based on which the choices are selected.
-A default module is provided, to be instantiated when the design is not specialized or it is not specialised for a known case.
-Subsequently, modules can be specified for the known choices of the selected option group.
-The operation does not need to specify modules for all cases.
-The references must be either modules or extmodules.
-
-The type of the instance bundle is determined identically to regular instances.
-The port lists of all modules must match and the ports are limited to ground and aggregate types.
+The type of an instance choice is the same as an instantiation of the default module.
+The ports of all module choices must be the same as the default module.
 
 ### Memories
 


### PR DESCRIPTION
Add option and instance choice features to the FIRRTL spec. Define an ABI for these that uses files similar to how layers work.

There are more examples of syntax and possible ABIs in this repository: https://github.com/seldridge/instance-choice-abis

### More Information

This feature exists to serve two separate purposes both related to allowing for limited parameterization of a FIRRTL circuit. This parameterization is later removed via _specialization_ either: (1) by a FIRRTL compiler or (2) via Verilog elaboration.

_Targets_ describe available paramterization as well as legal _options_ for that target. (Names subject to change.) These target can then be used by FIRRTL constructs to describe behavior which is dependent on the value of a target.

Currently, only one construct can depend on the value of a target: _instance choice_. An instance choice is an instantiation of one of several modules where the choice of instantiation is controlled by the option selected for a given target. E.g., a likely target is one which captures "FPGA or ASIC or Generic" that, when set, can specialize the design for an FPGA, and ASIC, or give generic Verilog. E.g., a more "parameter-like" target would be one that sets the cache size.

All modules instantiated by an instance choice must have the exact same port-level interface including probes and properties. This is necessary to allow them to be substituted. The underlying hardware backing the probes and properties may vary from one instance choice to another. _This is intentional and critical for this to be useful._ Properties require no special treatment other than a specialization must be chosen before properties can be evaluated. Probes require tedious Verilog macros that allow the Verilog-level specialization to set the internal path.