### PR TITLE
Update Initialization Coverage spec for zero-width

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1616,8 +1616,10 @@ module MyModule :
 ```
 
 This is an illegal FIRRTL circuit and an error will be thrown during compilation.
-All wires, memory ports, instance ports, and module ports that can be connected to must be connected to under all conditions.
+All non-zero-width wires, memory ports, instance ports, and module ports that can be connected to must be connected to under all conditions.
 Registers do not need to be connected to under all conditions, as it will keep its previous value if unconnected.
+Zero-width wires, memory ports, instance ports, and module ports do not need to be connected.
+These are implicitly initialized with a value of zero.
 
 ## Conditional Scopes
 


### PR DESCRIPTION
Specify that non-zero-width components must be initialized, while zero-width components are implicitly initialized with value zero.