### PR TITLE
[patch] Define Storable types

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -13,6 +13,7 @@ revisionHistory:
       - Reorganized statements section.
       - Rewrite of the Types section.
       - Fix mistake in layer-associated probe grammar.
+      - Define "Storable Type".
     abi:
       - Add ABI for public modules and filelist output.
       - Changed ABI for group and ref generated files.

--- a/spec.md
+++ b/spec.md
@@ -785,7 +785,7 @@ Enumerations are disjoint union types.
 
 Each enumeration consists of a set of variants.
 Each variant is named with a tag.
-Each variant also has a type associated with it which must be connectable (see [@sec:connectable-types]), storable (see [@sec:storable-types]), passive (see [@sec:passive-types]).
+Each variant also has a type associated with it which must be connectable (see [@sec:connectable-types]) and passive (see [@sec:passive-types]).
 
 In the following example, the first variant has the tag `a`{.firrtl} with type `UInt<8>`{.firrtl}, and the second variant has the tag `b`{.firrtl} with type `UInt<16>`{.firrtl}.
 
@@ -878,7 +878,7 @@ A **storable type** is a type which may appear as the type of a register or the 
 A storable type is defined recursively:
 
 -   All non-`const`{.firrtl} integer types are storable.
--   All non-`const`{.firrtl} enumeration types are storable.
+-   A non-`const`{.firrtl} enumeration types are storable if and only if the type of each of its variants is storable.
 -   A non-`const`{.firrtl} vector type is storable if and only if the element type is storable.
 -   A non-`const`{.firrtl} bundle type is storable if and only if it contains no field which is marked `flip`{.firrtl} and the type of each field is storable.
 

--- a/spec.md
+++ b/spec.md
@@ -870,26 +870,31 @@ A connectable type is defined recursively:
 -   bundles where each field type is a connectable type, or
 -   an enumeration type
 
+## Storable Types
+
+Stateful elements, such as registers and memories, are restricted in what types they can store.
+A **storable type** is a type which may appear as the type of a register or the element type of a memory.
+
+A storable type is defined recursively:
+
+-   All non-`const`{.firrtl} integer types are storable.
+-   All non-`const`{.firrtl} enumeration types are storable.
+-   A non-`const`{.firrtl} vector type is storable if and only if the element type is storable.
+-   A non-`const`{.firrtl} bundle type is storable if and only if it contains no field which is marked `flip`{.firrtl} and the type of each field is storable.
+
 ## Passive Types
 
-Stateful elements, such as registers and memories, may contain data of aggregate types.
-Registers with bundle types are especially common.
-However, when using bundle types in stateful elements, the notion of `flip`{.firrtl} does not make sense.
-There is no directionality to the data inside a register; the data just *is*.
-
+In certain contexts, the notion of `flip`{.firrtl} does not make sense.
 A **passive type** is a type which does not make use of `flip`{.firrtl}.
 
-More precisely, a passive type is defined recursively:
+A passive type is defined recursively:
 
 -   All ground types are passive.
 -   All probe types are passive.
 -   All property types are passive.
 -   A vector type is passive if and only if the element type is passive.
--   A bundle type is passive if and only if it contains no field which is marked `flip`{.firrtl}
-    and the type of each field is passive.
+-   A bundle type is passive if and only if it contains no field which is marked `flip`{.firrtl} and the type of each field is passive.
 -   All enumeration types are passive.
-
-Registers and memories may only be parametrized over passive types.
 
 ## Constant Types
 

--- a/spec.md
+++ b/spec.md
@@ -434,7 +434,7 @@ The type of a wire is given after the colon (`:`{.firrtl}).
 Registers are stateful elements of a design.
 
 The state of a register is controlled through what is connected to it (see [@sec:connections]).
-The state may be any non-`const`{.firrtl} passive type (see [@sec:passive-types]).
+The state may be any storable type (see [@sec:storable-types]).
 Registers are always associated with a clock.
 Optionally, registers may have a reset signal.
 
@@ -536,7 +536,7 @@ mem mymem :
 
 The type of a memory is a bundle type derived from the declaration (see [@sec:memories]).
 
-The type named in `data-type`{.firrtl} must be passive.
+The type named in `data-type`{.firrtl} must be storable (see [@sec:storable-types]).
 It indicates the type of the data being stored inside of the memory.
 
 See [@sec:memories] for more details.
@@ -785,7 +785,7 @@ Enumerations are disjoint union types.
 
 Each enumeration consists of a set of variants.
 Each variant is named with a tag.
-Each variant also has a type associated with it which must be connectable (see [@sec:connectable-types]) and passive (see [@sec:passive-types]).
+Each variant also has a type associated with it which must be connectable (see [@sec:connectable-types]), storable (see [@sec:storable-types]), passive (see [@sec:passive-types]).
 
 In the following example, the first variant has the tag `a`{.firrtl} with type `UInt<8>`{.firrtl}, and the second variant has the tag `b`{.firrtl} with type `UInt<16>`{.firrtl}.
 
@@ -1395,7 +1395,7 @@ A register is a stateful circuit component.
 Reads from a register return the current value of the element, writes are not visible until after the next positive edge of the register's clock.
 
 The clock signal for a register must be of type `Clock`{.firrtl}.
-The type of a register must be a passive type (see [@sec:passive-types]) and may not be `const`{.firrtl}.
+The type of a register must be a storable type (see [@sec:storable-types]).
 
 Registers may be declared without a reset using the `reg`{.firrtl} syntax and with a reset using the `regreset`{.firrtl} syntax.
 
@@ -1736,7 +1736,7 @@ connect w.b, x.b
 A memory is an abstract representation of a hardware memory.
 It is characterized by the following parameters.
 
-1.  A passive type representing the type of each element in the memory.
+1.  A storable type representing the type of each element in the memory (see [@sec:storable-types]).
 
 2.  A positive integer literal representing the number of elements in the memory.
 


### PR DESCRIPTION
# Storable Types
This PR defines a new term "Storable Type" which captures the class of FIRRTL types which are admissible inside of registers and memories.

## Isn't this just like Passive?
Yes.

The definition has a large overlap with the term Passive Type. And that is not a coincidence.

The term Passive Type has been used to designate 'types without flips'. However, with the introduction of Probe Types and also Property types, more nuance is required to handle types. Arguments have been made both for and against the above types being allowed be passive.

In order to help resolve this tension, the new term Storable Type is intended to separate out one particular usage of Passive Types.

## What is different between Passive and Storable?

Some notable differences between Passive and Storable:

1. Clocks and Resets are Passive but not Storable
1. Analogs are Passive but not Storable.
1. Properties are not Storable
1. Probes are not Storable 
1. Any structural part of a type being `const` disqualifies it from being Storable.

No. 1 acknowledges the special nature of Clocks and Resets.

I would insist on No. 2 on the grounds that `Analog` isn't very well-specified. We can always add it in later once we have a better foundation for it.

No. 3 and No. 4 are the primary motivation. Properties are easy to exclude, as we have stipulated they are not to affect the RTL, but rather serve as metadata to it. For probes, we use a similar appeal to the non-"hardware-y-ness" of probes, combined with the fact that storing a probe in a register requires a nontrivial encoding (and ultimately is likely to wind up meaningless).

No. 5 is a lesson from @darthscsi (feel free to forward attribution if needed) who pointed out to me that you can use `const` registers to create a mutating `const` value. This PR removes the non-`const` restriction from registers, as it is subsumed into this definition. (The spec seems to have forgotten to include a `const` restriction on memories).

## Why doesn't this PR remove the term Passive?

The term Passive still exists after this PR goes through. It still requires a bit of investigation to work out what role passivity plays in FIRRTL. There are only a handful of places in the spec Passive Types are referenced:

* Inside the definition itself (11 times out of 18)
* Rule 3 of the Connection Rules
  * Either the flow of the right-hand side expression is source or duplex, or the right-hand side expression has a **passive type**.
* One incidental time in an example about probes (can probably be removed safely)
* Talking about non-passive force targets (2 times)
* Talking about multiplexers
* Once talking about the types of probes
* Once in the definition of enumeration types

This gives us only a handful of places where we need to apply scrutiny. But none of these cases is so clear cut I feel I could change or remove them without changing the interpretation of the spec.