### PR TITLE
[major] Change the minimum width of the result of "Shift Right" for UInt to 0-bit

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -13,6 +13,7 @@ revisionHistory:
       - Reorganized statements section.
       - Rewrite of the Types section.
       - Fix mistake in layer-associated probe grammar.
+      - Change the minimum width of the result of "Shift Right" on UInt to 0-bit.
     abi:
       - Add ABI for public modules and filelist output.
       - Changed ABI for group and ref generated files.

--- a/spec.md
+++ b/spec.md
@@ -2999,7 +2999,7 @@ n must be non-negative.
   --------------------------------------------------------------------------
   Name   Arguments   Parameters   Arg Types   Result Type   Result Width
   ------ ----------- ------------ ----------- ------------- ----------------
-  shr    \(e\)       \(n\)        (UInt)      UInt          max(w~e~-n, 1)
+  shr    \(e\)       \(n\)        (UInt)      UInt          max(w~e~-n, 0)
 
                                   (SInt)      SInt          max(w~e~-n, 1)
   --------------------------------------------------------------------------


### PR DESCRIPTION
Change the minimum width of the result of "Shift Right" to 0-bit to align the behavior between Chisel and CIRCT.

Context: https://github.com/chipsalliance/chisel/pull/3752#issuecomment-1905086931, https://github.com/chipsalliance/chisel/pull/3752#issuecomment-1906225248 and chipsalliance/chisel#3735.