### PR TITLE
[nfc] Add ability to test code snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,22 @@
 -   Match terminology and capitalization preferences used elsewhere by default.
 -   Don't forget to spell-check!
 
+## Code Blocks
+
+Code blocks containing FIRRTL, Verilog, or SystemVerilog are, by default, extracted to separate files in the build area and passed through `firtool` or `verilator` to check that they are correct.
+You can run this manually with `make test`.
+
+Sometimes, you may want to prune the code block in the generated specification `.pdf`.
+You can do this by inserting special keywords in the code block:
+
+-   `snippetbegin` starts a snippet
+-   `snippetend` ends a snippet
+
+If a code block has more than one snippet, then each snippet is appended in the output `.pdf`.
+
+You may prevent a code block from being checked by adding a second class with name `notest` to the code block.
+E.g., put the following on a FIRRTL code block to cause it to not be tested: `{.firrtl .notest}`.
+
 ## Pushing Changes
 
 1.  Read the [Versioning Scheme of this

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IMG_SRCS=$(shell find include/img_src/ -type f -name '*.dot')
 IMG_EPSS=$(IMG_SRCS:include/img_src/%.dot=build/%.eps)
 IMG_PNG=$(IMG_SRCS:include/img_src/%.dot=build/%.png)
 
-.PHONY: all clean format images
+.PHONY: all clean format images test
 .PRECIOUS: build/ build/img/
 
 all: build/spec.pdf build/abi.pdf
@@ -18,6 +18,11 @@ format:
 
 images: $(IMG_EPSS) $(IMG_PNGS)
 
+test: build/spec.pdf build/abi.pdf | build/
+	find build/ -type f -name '*.fir' | xargs -n1 firtool -parse-only -disable-annotation-unknown -o /dev/null
+	find build/ -type f -name '*.v' | xargs -n1 verilator --default-language 1364-2005 -Wall -Wno-DECLFILENAME -Wno-UNDRIVEN -Wno-UNUSEDSIGNAL -Wno-UNUSEDPARAM -Wno-MULTITOP --lint-only -o /dev/null
+	find build/ -type f -name '*.sv' | xargs -n1 verilator --default-language 1800-2017 -Wall -Wno-DECLFILENAME -Wno-UNDRIVEN -Wno-UNUSEDSIGNAL -Wno-UNUSEDPARAM -Wno-MULTITOP --lint-only -o /dev/null
+
 PANDOC_FLAGS=\
 	--pdf-engine=latexmk \
 	--pdf-engine-opt=-logfilewarninglist \
@@ -27,9 +32,10 @@ PANDOC_FLAGS=\
 	--syntax-definition include/ebnf.xml \
 	-r markdown+table_captions+inline_code_attributes+gfm_auto_identifiers \
 	--filter pandoc-crossref \
+	--lua-filter scripts/extract-firrtl-code.lua \
 	--metadata version:$(VERSION)
 
-build/%.pdf: %.md %.yaml revision-history.yaml include/contributors.json include/common.yaml include/spec-template.tex include/firrtl.xml include/ebnf.xml $(IMG_EPSS) | build/
+build/%.pdf: %.md %.yaml revision-history.yaml include/contributors.json include/common.yaml include/spec-template.tex include/firrtl.xml include/ebnf.xml scripts/extract-firrtl-code.lua $(IMG_EPSS) | build/
 	pandoc $< --metadata-file $*.yaml --metadata-file=revision-history.yaml --metadata-file=include/contributors.json --metadata-file=include/common.yaml $(PANDOC_FLAGS) -o $@
 
 build/%.eps: include/img_src/%.dot | build/

--- a/scripts/extract-firrtl-code.lua
+++ b/scripts/extract-firrtl-code.lua
@@ -1,0 +1,76 @@
+index = 0
+
+-- Return the indices of all strings in `text` that are between `snippetbegin`
+-- and `snippetend` strings.
+function getSnippets (text)
+   local foundSnippet = false
+   local i = 0
+   local start
+   local snippets = {}
+   while true do
+      if start == nil then
+         _, i = string.find(text, "snippetbegin.-\n", i + 1)
+         if i == nil then
+            break
+         end
+         -- Increment by one to drop the newline from the snippet.
+         start = i + 1
+         -- Decrement 'i' so that there is _always_ a newline for the match in
+         -- the else block to use.  This makes it possible to match emtpy
+         -- snippets easily as they look exactly like non-empty snippets.
+         i = i - 1
+      else
+         e, i = string.find(text, "\n[^\n]-snippetend", i + 1)
+         if i == nil then
+            error("missing 'snippetend'")
+         end
+         table.insert(snippets, {i = start, e = e - 1})
+         start = nil
+      end
+   end
+   return snippets
+end
+
+function CodeBlock(elem)
+   local extMap = {
+      firrtl = "fir",
+      verilog = "v",
+      systemverilog = "sv"
+   }
+   local ext = extMap[elem.classes[1]]
+   local skip = elem.classes[2] == "notest"
+
+   -- Early exit if we don't know a file extension for this code block.
+   if (not ext) or skip then
+      return
+   end
+
+   -- Write the entire code block to a file.
+   local filename = string.format("build/%s-code-example-%03d.%s", PANDOC_STATE.input_files[1], index, ext)
+   index = index + 1
+
+   local f = io.open(filename, 'w')
+   f:write(elem.text)
+   f:write("\n")
+   f:close()
+
+   local snippets = getSnippets(elem.text)
+
+   -- If no snippets were found, return the original code block.
+   if next(snippets) == nil then
+      return pandoc.CodeBlock(elem.text, elem.attr)
+   end
+
+   -- Otherwise, extract all the snippets and return a new code block.
+   local newtext
+   for i, snippet in ipairs(snippets) do
+      local a = string.sub(elem.text, snippet.i, snippet.e)
+      if newtext == nil then
+         newtext = a
+      else
+         newtext = newtext .. "\n" .. a
+      end
+   end
+
+   return pandoc.CodeBlock(newtext, elem.attr)
+end


### PR DESCRIPTION
This demonstrates a flow that can be used to validate that all code
snippets used in the FIRRTL specification correctly parse.  This is
implemented using a simple pandoc filter to extract the bodies of all code
blocks with known languages (FIRRTL and Verilog), write them to the build
directory, and then run them all through an appropriate tool based on file
extension (firtool or verilator).

This may be a little cumbersome as every code example has to be completely
legal.  To alleviate this, this PR includes the ability to add special
delimiters, indicated by lines with the text `snippetbegin`/`snippetend` which
will cause the filter to extract only the lines between the delimiters.

CC: @dtzSiFive 