### PR TITLE
[minor] Add Property primitive operation for integer shift right.

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -18,6 +18,7 @@ revisionHistory:
       - Add Property primitive operations, starting with integer addition
       - Define/clarify layer-colored probe semantics.
       - Add Property primitive operation for integer multiplication
+      - Add Property primitive operation for integer shift right
     abi:
       - Add ABI for public modules and filelist output.
       - Changed ABI for group and ref generated files.

--- a/spec.md
+++ b/spec.md
@@ -3113,6 +3113,15 @@ The add operation result is the arbitrary precision signed integer arithmetic su
 
 The multiply operation result is the arbitrary precision signed integer arithmetic product of e1 and e2.
 
+### Integer Shift Right Operation
+
+  Name          Arguments   Arg Types           Result Type
+  ------------- ----------- ------------------- -------------
+  integer_shr   (e1,e2)     (Integer,Integer)   Integer
+
+The shift right operation result is the arbitrary precision signed integer arithmetic shift right of e1 by e2.
+e2 sign bits from e1 are shifted into the most significant bits, and the e2 least significant bits of e1 are truncated.
+
 # Notes on Syntax
 
 FIRRTL's syntax is designed to be human-readable but easily algorithmically parsed.
@@ -3575,7 +3584,7 @@ primop_1expr1int_keyword =
 primop_1expr2int_keyword = "bits" ;
 
 property_primop_2expr_keyword =
-    "integer_add" | "integer_mul" ;
+    "integer_add" | "integer_mul" | "integer_shr" ;
 ```
 
 # Versioning Scheme of this Document

--- a/spec.md
+++ b/spec.md
@@ -3121,6 +3121,7 @@ The multiply operation result is the arbitrary precision signed integer arithmet
 
 The shift right operation result is the arbitrary precision signed integer arithmetic shift right of e1 by e2.
 e2 sign bits from e1 are shifted into the most significant bits, and the e2 least significant bits of e1 are truncated.
+e2 must be non-negative.
 
 # Notes on Syntax
 


### PR DESCRIPTION
This adds the integer shift right operation to the Integer Arithmetic section and list of primitive operations in the grammar. This is defined as signed arithmetic shift right, as opposed to logical shift right, using similar language to the dshr operation.