### PR TITLE
[nfc] Bump pandoc/pandoc-crossref

### DIFF
--- a/.github/workflows/continuous-integration-ci.yml
+++ b/.github/workflows/continuous-integration-ci.yml
@@ -10,8 +10,8 @@ on:
       - main
 
 env:
-  pandoc-version: 3.1.11.1
-  pandoc-crossref-version: v0.3.17.0c
+  pandoc-version: 3.1.12.2
+  pandoc-crossref-version: v0.3.17.0d
   pandoc-install-dir: /opt/pandoc
   tabby-cad-version: 2024-02-18
 


### PR DESCRIPTION
Bump both pandoc and pandoc-crossref now that the latter has a release compatible with the latest pandoc version.