### PR TITLE
[major] Make commas mandatory, not whitespace

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -24,6 +24,7 @@ revisionHistory:
       - Drop support for input probes.
       - Add "enablelayer" to grammar.
       - Main module must be public.
+      - Make commas mandatory, not whitespace.
     abi:
       - Add ABI for public modules and filelist output.
       - Changed ABI for group and ref generated files.

--- a/spec.md
+++ b/spec.md
@@ -3910,7 +3910,6 @@ E.g., it is legal to use `` `0` ``{.firrtl} as a literal identifier in a Bundle 
 A FIRRTL compiler is allowed to change a literal identifier to a legal identifier in the target language (e.g., Verilog) if the literal identifier is not directly representable in the target language.
 
 Comments begin with a semicolon and extend until the end of the line.
-Commas are treated as whitespace, and may be used by the user for clarity if desired.
 
 In FIRRTL, indentation is significant.
 Indentation must consist of spaces only---tabs are illegal characters.


### PR DESCRIPTION
Remove the syntax note that that commas are whitespace.  This has historically never been utilized (by Chisel) and is a strange language choice.

Fixes #188.