### PR TITLE
[patch] Clarify existing when behavior

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -31,6 +31,7 @@ revisionHistory:
       - Add intrinsic expressions and statements.
       - Remove intrinsic modules.
       - Allow layerbocks anywhere in a module.
+      - Add language clarifying behavior statements affected by conditionals.
     abi:
       - Add ABI for public modules and filelist output.
       - Changed ABI for group and ref generated files.

--- a/spec.md
+++ b/spec.md
@@ -1623,7 +1623,6 @@ Conditional statements define one or more regions, each with an associated condi
 These regions contain other statements (including nested conditional statements).
 The behavior of the contained statements is affected by the conditions associated to the regions containing them.
 
-
 ## Conditional Statements
 
 FIRRTL provides several kinds of conditional statements.
@@ -1828,7 +1827,6 @@ circuit Foo:
     ;; snippetend
 ```
 
-
 ## Conditional Execution
 
 Statements that appear in a conditional region behave differently based on the type of statement and on the conditions of the blocks containing it.
@@ -1847,7 +1845,6 @@ For hardware component declarations, conditional regions have no effect.
 > A register in a conditional region and an instantiation in a conditional region where the instantiated module contains a register will execute the same after a trivial inlining.
 > A command in a conditional region and a module instantiation in a conditional region where the instantiated module contains a command will not execute the same after a trivial inlining.
 > In this latter case, the command is not conditional before trivial inlining and conditional after trivial inlining.
-
 
 ## Initialization Coverage
 
@@ -1880,7 +1877,6 @@ Circuit components declared within condition regions may only be referred to wit
 > The behavior is also a bit non-intuitive at first.
 > This differs from the behavior in most programming languages, where variables in a local scope can shadow variables declared outside that scope.
 > Additionally, while the names *exist* in the module's namespace, those names cannot be *used* outside of the region which they are declared.
-
 
 ## Conditional Last Connect Semantics
 

--- a/spec.md
+++ b/spec.md
@@ -1873,10 +1873,12 @@ Registers do not need to be connected to under all conditions, as it will keep i
 ## Declarations within Conditional Regions
 
 The names of circuit components declared within conditional regions must be unique within their module's namespace (see [@sec:namespaces]).
+Circuit components declared within condition regions may only be referred to within that region.
 
+> The behavior is also a bit non-intuitive at first.
 > This differs from the behavior in most programming languages, where variables in a local scope can shadow variables declared outside that scope.
+> Additionally, while the names *exist* in the module's namespace, those names cannot be *used* outside of the region which they are declared.
 
-Circuit components declared within condition regions may only be used by operations within the same conditional scope or a child conditional scope.
 
 ## Conditional Last Connect Semantics
 

--- a/spec.md
+++ b/spec.md
@@ -1617,7 +1617,10 @@ A register is initialized with an indeterminate value (see [@sec:indeterminate-v
 
 # Conditionals
 
-Conditional statements define one or more regions where the operations (declarations, statements, and expressions) inside these regions *conditionally execute* based on the value of a condition.
+Conditional statements define one or more regions, each with an associated condition.
+These regions contain other statements (including nested conditional statements).
+The behavior of the contained statements is affected by the conditions associated to the regions containing them.
+
 
 ## Conditional Statements
 

--- a/spec.md
+++ b/spec.md
@@ -1619,24 +1619,6 @@ A register is initialized with an indeterminate value (see [@sec:indeterminate-v
 
 Conditional statements define one or more regions where the operations (declarations, statements, and expressions) inside these regions *conditionally execute* based on the value of a condition.
 
-## Conditional Execution
-
-The *conditional execution* of operations within a region is both operation-dependent and defined in terms of all *parent conditions*.
-A condition is a *parent condition* of an operation if the operation is defined under a conditional region with that condition.
-Operations have more than one parent condition when conditional statements are nested.
-
-Conditional execution is defined as follows:
-
--   Connections (see [@sec:connections]) to a sink only execute when the product (logical and) of all conditions that are parents of the connect, but not parents of the declaration defining the sink evaluate to true.
--   Commands (see [@sec:commands]) only execute when the product (logical and) of all parent conditions evaluates to true.
--   The execution of all other operations in conditional regions is unaffected by the condition.
-    E.g., register, wire, and node declarations as well as module instantiation statements and primitive operation expressions may occur in conditional regions but never execute conditionally.
-
-> These semantics may cause different behavior for trivial inlining (substitution of an instantiation's module body in place of the instantiation).
-> A register in a conditional region and an instantiation in a conditional region where the instantiated module contains a register will execute the same after a trivial inlining.
-> A command in a conditional region and a module instantiation in a conditional region where the instantiated module contains a command will not execute the same after a trivial inlining.
-> In this latter case, the command is not conditional before trivial inlining and conditional after trivial inlining.
-
 ## Conditional Statements
 
 FIRRTL provides several kinds of conditional statements.
@@ -1840,6 +1822,26 @@ circuit Foo:
         connect e, f
     ;; snippetend
 ```
+
+
+## Conditional Execution
+
+The *conditional execution* of operations within a region is both operation-dependent and defined in terms of all *parent conditions*.
+A condition is a *parent condition* of an operation if the operation is defined under a conditional region with that condition.
+Operations have more than one parent condition when conditional statements are nested.
+
+Conditional execution is defined as follows:
+
+-   Connections (see [@sec:connections]) to a sink only execute when the product (logical and) of all conditions that are parents of the connect, but not parents of the declaration defining the sink evaluate to true.
+-   Commands (see [@sec:commands]) only execute when the product (logical and) of all parent conditions evaluates to true.
+-   The execution of all other operations in conditional regions is unaffected by the condition.
+    E.g., register, wire, and node declarations as well as module instantiation statements and primitive operation expressions may occur in conditional regions but never execute conditionally.
+
+> These semantics may cause different behavior for trivial inlining (substitution of an instantiation's module body in place of the instantiation).
+> A register in a conditional region and an instantiation in a conditional region where the instantiated module contains a register will execute the same after a trivial inlining.
+> A command in a conditional region and a module instantiation in a conditional region where the instantiated module contains a command will not execute the same after a trivial inlining.
+> In this latter case, the command is not conditional before trivial inlining and conditional after trivial inlining.
+
 
 ## Initialization Coverage
 

--- a/spec.md
+++ b/spec.md
@@ -1829,16 +1829,17 @@ circuit Foo:
 
 ## Conditional Execution
 
-The *conditional execution* of operations within a region is both operation-dependent and defined in terms of all *parent conditions*.
-A condition is a *parent condition* of an operation if the operation is defined under a conditional region with that condition.
-Operations have more than one parent condition when conditional statements are nested.
+Statements that appear in a conditional region behave differently based on the type of statement and on the conditions of the blocks containing it.
 
-Conditional execution is defined as follows:
+For connections (see [@sec:connections]), appearing inside of a conditional block affects whether or not the connect executes.
+The sink of a connect operator will correspond to a circuit component declared earlier in the module.
+We consider the conditions associated to the regions of all conditional blocks which contain the connect statement, but which do *not* contain the declaration of the circuit component.
+We call this set of conditions the **interleaving conditions** of the connect.
+Whenever we determine the last connect semantics (see [@sec:last-connect-semantics]) for that component, if each of the interleaving conditions is true, then that connect is executed.
 
--   Connections (see [@sec:connections]) to a sink only execute when the product (logical and) of all conditions that are parents of the connect, but not parents of the declaration defining the sink evaluate to true.
--   Commands (see [@sec:commands]) only execute when the product (logical and) of all parent conditions evaluates to true.
--   The execution of all other operations in conditional regions is unaffected by the condition.
-    E.g., register, wire, and node declarations as well as module instantiation statements and primitive operation expressions may occur in conditional regions but never execute conditionally.
+For commands (see [@sec:commands]), we instead consider the conditions associated with *each* containing conditional region.
+
+For hardware component declarations, conditional regions have no effect.
 
 > These semantics may cause different behavior for trivial inlining (substitution of an instantiation's module body in place of the instantiation).
 > A register in a conditional region and an instantiation in a conditional region where the instantiated module contains a register will execute the same after a trivial inlining.

--- a/spec.md
+++ b/spec.md
@@ -228,6 +228,8 @@ endmodule
 ## Layers
 
 Layers are collections of functionality which will not be present in all executions of a circuit.
+
+During execution, each layer is either enabled or disabled.
 When a layer is enabled, the FIRRTL circuit behaves *as-if* all the optional functionality of that layer was included in the normal execution of the circuit.
 When a layer is disabled, the circuit behaves *as-if* all the optional functionality of that layer was removed from the execution of the circuit.
 Layers are intended to be used to keep verification, debugging, or other collateral, not relevant to the operation of the circuit, in a separate area.

--- a/spec.md
+++ b/spec.md
@@ -1630,9 +1630,9 @@ FIRRTL provides several kinds of conditional statements.
 
 When statements define a condition and two conditional regions: a "then" region and an "else" region.
 The condition must be a 1-bit unsigned integer type.
-Operations within the "then" region are conditionally executed when the condition is true.
-Operations within the "else" region are conditionally executed when the condition is false.
-Operations within regions are executed using the rules in [@sec:conditional-execution].
+Statements within the "then" region are conditionally executed when the condition is true.
+Statements within the "else" region are conditionally executed when the condition is false.
+Statements within regions are executed using the rules in [@sec:conditional-execution].
 
 In the following example, the wire `x`{.firrtl} is connected to the input `a`{.firrtl} only when the `en`{.firrtl} signal is high.
 Otherwise, the wire `x`{.firrtl} is connected to the input `b`{.firrtl}.
@@ -1804,8 +1804,8 @@ circuit Foo:
 
 ### Match Statements
 
-Match statements define regions whose operations are executed when the value of an enumeration typed expression is equal to an enumeration variant.
-Operations within regions are executed using the rules in [@sec:conditional-execution].
+Match statements define regions whose statements are executed when the value of an enumeration typed expression is equal to an enumeration variant.
+Statements within regions are executed using the rules in [@sec:conditional-execution].
 A match statement must exhaustively test every variant of an enumeration.
 An optional binder may be specified to extract the data of the variant.
 


### PR DESCRIPTION
Add language that defines what conditionals are (they are a region where the operations in the region change their behavior based on the condition) and how different operations are affected by the condition.  This fills a hole where the behavior of commands was not explicitly specified.  Add an aside that clarifies that this means that a _trivial_ inlining will not work as a user might expect.