### PR TITLE
[major] Adjust syntax of formal unit tests

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -29,7 +29,7 @@ revisionHistory:
       - Add language clarifying behavior statements affected by conditionals.
       - No abstract reset on externally-defined modules.
       - Add Property type and primitive operations for List.
-      - Add "formal" construct to mark modules for bounded model checking.
+      - Add `formal` unit test construct.
       - Add Property primitive operation for integer shift left
     abi:
       - Use EBNF to describe probe port macros and filename.


### PR DESCRIPTION
Adjust the syntax of the `formal` declaration to no longer expect a single fixed `bound = <N>` parameter, but instead accept a list of user-defined parameters similar to an `extmodule`. The parameters can be integers, strings, arrays, and dictionaries. They are passed through to the tooling running the formal test. As we build out that tooling, we may standardize some of the parameters.

Marking this as "major" since it technically is a breaking change, but in practice there are no users of `formal` as of today and the original syntax has never been released as part of the spec.