### PR TITLE
[nfc] Bump Pandoc to version 4

### DIFF
--- a/.github/workflows/continuous-integration-ci.yml
+++ b/.github/workflows/continuous-integration-ci.yml
@@ -10,8 +10,8 @@ on:
       - main
 
 env:
-  pandoc-version: 3.1.12.2
-  pandoc-crossref-version: v0.3.17.0d
+  pandoc-version: 3.4
+  pandoc-crossref-version: v0.3.18.0
   pandoc-install-dir: /opt/pandoc
   tabby-cad-version: 2024-02-18
 

--- a/include/spec-template.tex
+++ b/include/spec-template.tex
@@ -342,15 +342,17 @@ $endif$
 $if(graphics)$
 \usepackage{graphicx}
 \makeatletter
-\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
-\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
-\makeatother
-% Scale images if necessary, so that they will not overflow the page
-% margins by default, and it is still possible to overwrite the defaults
-% using explicit options in \includegraphics[width, height, ...]{}
-\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+\newsavebox\pandoc@box
+\newcommand*\pandocbounded[1]{% scales image to fit in text height/width
+  \sbox\pandoc@box{#1}%
+  \Gscale@div\@tempa{\textheight}{\dimexpr\ht\pandoc@box+\dp\pandoc@box\relax}%
+  \Gscale@div\@tempb{\linewidth}{\wd\pandoc@box}%
+  \ifdim\@tempb\p@<\@tempa\p@\let\@tempa\@tempb\fi% select the smaller of both
+  \ifdim\@tempa\p@<\p@\scalebox{\@tempa}{\usebox\pandoc@box}%
+  \else\usebox{\pandoc@box}%
+  \fi%
+}
 % Set default figure placement to htbp
-\makeatletter
 \def\fps@figure{htbp}
 \makeatother
 $endif$

--- a/spec.md
+++ b/spec.md
@@ -51,9 +51,8 @@ During that time and since, there have been a number of contributions and improv
 To better reflect the work of contributors after the original tech report, the FIRRTL specification was changed to be authored by *The FIRRTL Specification Contributors*.
 A list of these contributors is below:
 
-```{=tex}
 \contributors
-```
+
 # File Preamble
 
 A FIRRTL file begins with a magic string and version identifier indicating the version of this standard the file conforms to (see [@sec:versioning-scheme-of-this-document]).
@@ -2694,12 +2693,12 @@ The `release`{.firrtl} and `release_initial`{.firrtl} statements end the forcing
 
 Like `read`{.firrtl}, the force statements are verification constructs.
 
-| Name            | Arguments                    | Argument Types                                                   |
-|-------------------|----------------------------------|-------------------|
-| force_initial   | (ref, val)                   | (`RWProbe<T>`{.firrtl}, T)                                       |
-| release_initial | (ref)                        | (`RWProbe<T>`{.firrtl})                                          |
-| force           | (clock, condition, ref, val) | (`Clock`{.firrtl}, `UInt<1>`{.firrtl}, `RWProbe<T>`{.firrtl}, T) |
-| release         | (clock, condition, ref)      | (`Clock`{.firrtl}, `UInt<1>`{.firrtl}, `RWProbe<T>`{.firrtl})    |
+| Name | Arguments | Argument Types |
+|-------------------|--------------------|---------------------------------|
+| force_initial | (ref, val) | (`RWProbe<T>`{.firrtl}, T) |
+| release_initial | (ref) | (`RWProbe<T>`{.firrtl}) |
+| force | (clock, condition, ref, val) | (`Clock`{.firrtl}, `UInt<1>`{.firrtl}, `RWProbe<T>`{.firrtl}, T) |
+| release | (clock, condition, ref) | (`Clock`{.firrtl}, `UInt<1>`{.firrtl}, `RWProbe<T>`{.firrtl}) |
 
 Backends optionally generate corresponding constructs in the target language, or issue an warning.
 
@@ -3472,13 +3471,13 @@ Figure [@fig:foo-unfolded] shows the completely unfolded representation where ea
 Using targets (or multiple targets), any specific module, instance, or combination of instances can be expressed.
 Some examples include:
 
-| Target            | Description                                                                     |
-|-------------------------------------------|-----------------------------|
-| `Foo`             | refers to module `Foo`{.firrtl} (or the only instance of module `Foo`{.firrtl}) |
-| `Bar`             | refers to module `Bar`{.firrtl} (or both instances of module `Bar`{.firrtl})    |
-| `Foo/a:Bar`       | refers just to one instance of module `Bar`{.firrtl}                            |
-| `Foo/b:Bar/c:Baz` | refers to one instance of module `Baz`{.firrtl}                                 |
-| `Bar/d:Baz`       | refers to two instances of module `Baz`{.firrtl}                                |
+| Target | Description |
+|-------------------------|-----------------------------------------------|
+| `Foo` | refers to module `Foo`{.firrtl} (or the only instance of module `Foo`{.firrtl}) |
+| `Bar` | refers to module `Bar`{.firrtl} (or both instances of module `Bar`{.firrtl}) |
+| `Foo/a:Bar` | refers just to one instance of module `Bar`{.firrtl} |
+| `Foo/b:Bar/c:Baz` | refers to one instance of module `Baz`{.firrtl} |
+| `Bar/d:Baz` | refers to two instances of module `Baz`{.firrtl} |
 
 If a target does not contain an instance path, it is a *local* target.
 A local target points to all instances of a module.
@@ -4253,9 +4252,8 @@ circuit Foo:
 Radix-specified integer literals are only usable when constructing hardware integer literals.
 Any use in place of an integer is disallowed.
 
-```{=tex}
 \clearpage
-```
+
 # Grammar
 
 ``` ebnf


### PR DESCRIPTION
Bump pandoc to a newer version.  This uses version 4 as that happens to be the latest version available in macports.  Version 5 is available.