### PR TITLE
[minor] Add inline layer convention

### DIFF
--- a/abi.md
+++ b/abi.md
@@ -331,7 +331,7 @@ To enable the functionality for all layer blocks under a public module, a user s
 The define uses the format below where `module` is the name of the public module, `root` is the name of the root-level layer and `nested` is the name of zero or more nested layers:
 
 ``` ebnf
-define = "layers_" , module , "$" , root , { "$" , nested } ;
+define = "layer_" , module , "$" , root , { "$" , nested } ;
 ```
 
 If an inline layer is nested under a bind layer, the name of the bind layer should be included in the define.
@@ -351,13 +351,13 @@ circuit Bar:
 When compiled to Verilog, this creates two Verilog modules.
 Verilog module `Bar` will be sensitive to the following defines:
 
-    layers_Bar$Layer1$Layer2
-    layers_Bar$Layer1$Layer2$Layer3
+    layer_Bar$Layer1$Layer2
+    layer_Bar$Layer1$Layer2$Layer3
 
 Verilog module `Baz` will be sensitive to the following defines:
 
-    layers_Baz$Layer1$Layer2
-    layers_Baz$Layer1$Layer2$Layer3
+    layer_Baz$Layer1$Layer2
+    layer_Baz$Layer1$Layer2$Layer3
 
 The effect of enabling a child inline layer *does not* enable its parent layers.
 

--- a/abi.md
+++ b/abi.md
@@ -134,9 +134,9 @@ Reference types in ports shall be logically split out from aggregates and named 
 The lowering convention of a layer specifies how the functionality contained within its associated layer block will both be represented after compilation and the mechanism to enable the functionality.
 There are two standard lowering conventions:
 
-1.  The `bind`{.firrtl} convention will "extract" layer blocks from the circuit into modules that are instantiated via SystemVerilog's `bind`{.verilog} feature.
+1.  The `bind`{.firrtl} convention will "extract" layer blocks from the circuit into modules that are instantiated via SystemVerilog's `bind`{.verilog} feature (Section 23.11 of IEEE 1800-2023).
     Functionality is enabled by including a file during compilation.
-2.  The `inline`{.firrtl} convention lowers the layer blocks to `` `ifdef ``{.verilog}-guarded regions.
+2.  The `inline`{.firrtl} convention lowers the layer blocks to `` `ifdef ``{.verilog}-guarded regions (Section 23.6 of IEEE 1800-2023).
     Functionality is enabled by defining a macro during Verilog elaboration.
 
 FIRRTL compilers may implement other non-standard lowering conventions.

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,7 +5,9 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
     spec:
+      - Add a second standard layer convention, "inelin".
     abi:
+      - Add inline layer convention ABI.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 4.0.0

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,7 +5,7 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
     spec:
-      - Add a second standard layer convention, "inelin".
+      - Add a second standard layer convention, "inline".
     abi:
       - Add inline layer convention ABI.
   # Information about the old versions.  This should be static.

--- a/spec.md
+++ b/spec.md
@@ -241,7 +241,7 @@ A layer may be declared in a circuit or in another layer declaration.
 A layer's identifier must be unique within the current namespace.
 I.e., the identifier of a top-level layer declared in a circuit must not conflict with the identifier of a module, external module, or implementation defined module.
 
-Layers may be arbitrarily nested, with the exceptions of convention constraints described below.
+Layers may be nested, with the exceptions of convention constraints described below.
 Nested layers are declared with the `layer`{.firrtl} keyword indented under an existing `layer`{.firrtl} keyword.
 
 Each layer must include a string that sets the *lowering convention* for that layer.

--- a/spec.md
+++ b/spec.md
@@ -241,12 +241,18 @@ A layer may be declared in a circuit or in another layer declaration.
 A layer's identifier must be unique within the current namespace.
 I.e., the identifier of a top-level layer declared in a circuit must not conflict with the identifier of a module, external module, or implementation defined module.
 
-Layers may be nested.
+Layers may be arbitrarily nested, with the exceptions of convention constraints described below.
 Nested layers are declared with the `layer`{.firrtl} keyword indented under an existing `layer`{.firrtl} keyword.
 
-Each layer must include a string that sets the lowering convention for that layer.
-The FIRRTL ABI specification defines supported lowering conventions.
-One such strategy is `bind`{.firrtl} which lowers to modules and instances which are instantiated using the SystemVerilog `bind`{.verilog} feature.
+Each layer must include a string that sets the *lowering convention* for that layer.
+The conventions defines both how the optional functionality is represented when the circuit is compiled to a backend language and the mechanism by which the layer's optional functionality can be enabled.
+For the purposes of FIRRTL execution, all layer conventions are the same---enabling the layer enables the optional functionality.
+
+There are two standard lowering conventions: `bind`{.firrtl} and `inline`{.firrtl}.
+For details of the representation and mechanism of these conventions, see the FIRRTL ABI Specification.
+Compilers may define other non-standard lowering conventions.
+
+A layer with the `bind`{.firrtl} convention may not be nested, or transitively nested, under a layer of `inline`{.firrtl} convention.
 
 The example below shows a circuit with layers `A`, `B`, and `B.C`:
 


### PR DESCRIPTION
Add the inline layer convention to the FIRRTL spec and FIRRTL ABI. Clarify some language in the spec around layers.