### PR TITLE
[minor] Add Instance Choice

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -7,6 +7,7 @@
       <item>extmodule</item>
       <item>layer</item>
       <item>formal</item>
+      <item>option</item>
     </list>
     <list name="keywords">
       <item>input</item>
@@ -28,6 +29,8 @@
       <item>public</item>
       <item>enablelayer</item>
       <item>bound</item>
+      <item>instchoice</item>
+      <item>option</item>
     </list>
     <list name="types">
       <item>UInt</item>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,7 +5,9 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
     spec:
+      - Add instance choice.
     abi:
+      - Add instance choice.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 4.0.0


### PR DESCRIPTION
Add instance choice, a new feature that allows for one of several possible instances to be instantiated at Verilog elaboration time.