### PR TITLE
[nfc] Bump upload-artifact version

### DIFF
--- a/.github/workflows/continuous-integration-ci.yml
+++ b/.github/workflows/continuous-integration-ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: "Test code blocks"
         run: make test
       - name: "Upload Build Directory"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build


### PR DESCRIPTION
Change from v3 to v4 as the former is no longer supported.