### PR TITLE
[patch] Replace "mod" with "rem" in primop_2expr_keyword rule

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,6 +5,7 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
     spec:
+      - Correct grammar for modulus primitive operator.
     abi:
   # Information about the old versions.  This should be static.
   oldVersions:

--- a/spec.md
+++ b/spec.md
@@ -4584,7 +4584,7 @@ primop_1expr_keyword =
   | "andr"   | "orr"    | "xorr" ;
 
 primop_2expr_keyword =
-    "add"  | "sub" | "mul" | "div" | "mod"
+    "add"  | "sub" | "mul" | "div" | "rem"
   | "lt"   | "leq" | "gt"  | "geq" | "eq" | "neq"
   | "dshl" | "dshr"
   | "and"  | "or"  | "xor" | "cat" ;


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/firrtl-spec/issues/276