### PR TITLE
[minor] Add %c to format string substitution

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -6,6 +6,7 @@ revisionHistory:
   thisVersion:
     spec:
       - Correct grammar for modulus primitive operator.
+      - Add `%c` format string substitution.
     abi:
   # Information about the old versions.  This should be static.
   oldVersions:

--- a/spec.md
+++ b/spec.md
@@ -2329,6 +2329,8 @@ Format strings support the following argument placeholders:
 
 -   `%b` : Prints the argument in binary
 
+-   `%c` : Prints the argument as an ASCII character
+
 -   `%d` : Prints the argument in decimal
 
 -   `%x` : Prints the argument in hexadecimal


### PR DESCRIPTION
Add (the missing) `%c` is sbustitution.  This has always been generated from Chisel, it was just never put in the FIRRTL spec.