### PR TITLE
[major] Add special substitutions

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,6 +5,7 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
     spec:
+      - Add special substitutions (`{{}}`) for format strings.
     abi:
   # Information about the old versions.  This should be static.
   oldVersions:

--- a/spec.md
+++ b/spec.md
@@ -2349,6 +2349,15 @@ Format strings support the following escape characters:
 
 -   `\'` : Single quote
 
+The following special substitutions are also allowed.
+These substitutions do not have corresponding operands:
+
+-   `{{SimulationTime}}` : Prints the current simulation time
+
+-   `{{HierarchicalModuleName}}` : Prints the complete hierarchical path from the root module to the module that contains this `printf`.
+
+-   `\{{` : Prints a literal `{{`. This can be used to escape a special substitution if you desire to have a literal `{{` appear in the output.
+
 ## Verification
 
 To facilitate simulation, model checking and formal methods, there are three non-synthesizable verification statements available: assert, assume and cover.


### PR DESCRIPTION
Add special substitutions.  These look like `{{Name}}`.  Add two special substitutions that we want to enable going forward:

  - `{{SimulationTime}}`
  - `{{HierarchicalModuleName}}`

This includes an escape sequence that can be used to get a literal `{{` in the output.  Over time, these are expected to be changed to include more special substitutions on an as-need basis.

This is a major change as it is backwards-incompatible with old FIRRTL versions.  This will break compilation of any code which used `{{` previously.