### PR TITLE
[major] Drop Circuit from Annotations

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -6,6 +6,7 @@ revisionHistory:
   thisVersion:
     spec:
       - Add special substitutions (`{{}}`) for format strings.
+      - Remove circuit from annotations
     abi:
   # Information about the old versions.  This should be static.
   oldVersions:

--- a/spec.md
+++ b/spec.md
@@ -3511,11 +3511,11 @@ The following shows a valid annotation file containing two annotations:
 [
   {
     "class":"hello",
-    "target":"~Foo|Bar"
+    "target":"Bar"
   },
   {
     "class":"world",
-    "target":"~Foo|Baz"
+    "target":"Baz"
   }
 ]
 ```
@@ -3529,11 +3529,11 @@ FIRRTL version 4.0.0
 circuit Foo: %[[
   {
     "class":"hello",
-    "target":"~Foo|Bar"
+    "target":"Bar"
   },
   {
     "class":"world",
-    "target":"~Foo|Baz"
+    "target":"Baz"
   }
 ]]
   module Baz :


### PR DESCRIPTION
Drop mentions of the "Circuit" from annotations.  We want to move away from this as the circuit name doesn't add anythiing meaningful other than locking a given annotation file to a circuit.  However, given that we have had the inline annotation format for a long time, this locking is unnecessary.

Pragmatically, this makes it easier to generate annotations from Chisel because the module name is always known, but the circuit name may not be. E.g., when compiling in a D/I environment where definitions are built and the instantiated in a separate circuit.

Note: the diff here is minimal.  The spec already has "targets" specified _without_ a circuit name in their EBNF grammar description.