### PR TITLE
[minor] Introduce fprintf

### DIFF
--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -5,13 +5,13 @@ revisionHistory:
   # additions to the specification should append entries here.
   thisVersion:
     spec:
+        - Add `fprintf` statement.
     abi:
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 5.0.0
       spec:
         - Add special substitutions (`{{}}`) for format strings.
-        - Add `fprintf` statement.
       abi:
     - version: 4.2.0
       spec:

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -11,6 +11,7 @@ revisionHistory:
     - version: 5.0.0
       spec:
         - Add special substitutions (`{{}}`) for format strings.
+        - Add `fprintf` statement.
       abi:
     - version: 4.2.0
       spec:

--- a/spec.md
+++ b/spec.md
@@ -2309,7 +2309,7 @@ However it can never be used in a reference since it is not of any valid type.
 The `fprintf`{.firrtl} statement outputs the string to a file specified by an additional string argument.
 
 ``` firrtl
-FIRRTL version 4.0.0
+FIRRTL version 5.1.0
 circuit Foo:
   public module Foo:
     ;; snippetbegin

--- a/spec.md
+++ b/spec.md
@@ -2306,6 +2306,8 @@ The `printf`{.firrtl} statement has an optional name attribute which can be used
 The name is part of the module level namespace.
 However it can never be used in a reference since it is not of any valid type.
 
+The `fprintf`{.firrtl} statement outputs the string to a file specified by an additional string argument.
+
 ``` firrtl
 FIRRTL version 4.0.0
 circuit Foo:
@@ -2317,6 +2319,9 @@ circuit Foo:
     wire b: UInt
     printf(
       clk, cond, "a in hex: %x, b in decimal:%d.\n", a, b
+    ) : optional_name
+    fprintf(
+      clk, cond, "test.txt", "hello\n"
     ) : optional_name
     ;; snippetend
 ```
@@ -4401,6 +4406,14 @@ command =
   | "printf" , "(" ,
         expr , "," ,
         expr , "," ,
+        string_dq ,
+        { "," , expr }
+    , ")" ,
+    [ ":" , id ] , [ info ]
+  | "fprintf" , "(" ,
+        expr , "," ,
+        expr , "," ,
+        string_dq ,
         string_dq ,
         { "," , expr }
     , ")" ,

--- a/spec.md
+++ b/spec.md
@@ -4413,7 +4413,7 @@ command =
   | "fprintf" , "(" ,
         expr , "," ,
         expr , "," ,
-        string_dq ,
+        string_dq , "," ,
         string_dq ,
         { "," , expr }
     , ")" ,


### PR DESCRIPTION
This PR proposes `fprtinf` operation that output strings to a file instead of default file descriptor. https://github.com/llvm/circt/pull/8346 is PR on CIRCT