### PR TITLE
[major] Drop module name from inline layer macro

### DIFF
--- a/abi.md
+++ b/abi.md
@@ -328,10 +328,10 @@ When using this convention, the functionality contained within layer blocks will
 The number and location of conditional compilation compiler directive code regions is implementation defined.
 
 To enable the functionality for all layer blocks under a public module, a user should set a preprocessor define during Verilog compilation to enable the conditional compilation compiler directives.
-The define uses the format below where `module` is the name of the public module, `root` is the name of the root-level layer and `nested` is the name of zero or more nested layers:
+The define uses the format below, where `root` is the name of the top-level layer and `nested` is the name of zero or more child layers:
 
 ``` ebnf
-define = "layer_" , module , "$" , root , { "$" , nested } ;
+define = "layer$" , root , { "$" , nested } ;
 ```
 
 If an inline layer is nested under a bind layer, the name of the bind layer should be included in the define.
@@ -349,17 +349,10 @@ circuit Bar:
 ```
 
 When compiled to Verilog, this creates two Verilog modules.
-Verilog module `Bar` will be sensitive to the following defines:
+Both Verilog modules `Bar` and `Baz` will be sensitive to the following defines:
 
-    layer_Bar$Layer1$Layer2
-    layer_Bar$Layer1$Layer2$Layer3
-
-Verilog module `Baz` will be sensitive to the following defines:
-
-    layer_Baz$Layer1$Layer2
-    layer_Baz$Layer1$Layer2$Layer3
-
-The effect of enabling a child inline layer *does not* enable its parent layers.
+    layer$Layer1$Layer2
+    layer$Layer1$Layer2$Layer3
 
 ## On Types
 

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -9,6 +9,7 @@ revisionHistory:
       - Add `fprintf` statement.
       - Add `fflush` statement.
     abi:
+     - Remove module name from guard macro for inline layers.
   # Information about the old versions.  This should be static.
   oldVersions:
     - version: 5.0.0


### PR DESCRIPTION
This PR changes the FIRRTL ABI for inline layers so that there is a single macro which, when defined, will enable the inline layer across all compilation units (circuits) in a design. This is done by removing the module-name from the macro used to enable the layer.

The type system for FIRRTL ensures that a layer-guarded hardware value is only accessed when the layer is enabled, but this is only true when a layer is enabled or disabled universally.

By including the module name in the inline layer macro, we have a distinct macro for enabling a layer for each module in a design, which would allow us to enable a layer on a module-by-module basis, which is not desirable.

Additionally, the ABI for inline macro names now uses `$` as a deliminator for name parts uniformly.

Before this PR, the macro format was:

```
layer_Module$Layer1$Layer2
```

Now, the format is:

```
layer$Layer1$Layer2
```

In a later change, we will be updating the ABI for ref names to use `$` as well.