### PR TITLE
Add knownlayer and enablelayer modifiers to extmodules

### DIFF
--- a/include/firrtl.xml
+++ b/include/firrtl.xml
@@ -27,6 +27,7 @@
       <item>propassign</item>
       <item>public</item>
       <item>enablelayer</item>
+      <item>knownlayer</item>
     </list>
     <list name="types">
       <item>UInt</item>

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -9,6 +9,7 @@ revisionHistory:
       - Add `fprintf` statement.
       - Add `fflush` statement.
       - Change a cat operation to accept variadic arguments.
+      - Add "knownlayer" modifier to extmodules.
     abi:
      - Remove module name from guard macro for inline layers.
   # Information about the old versions.  This should be static.

--- a/revision-history.yaml
+++ b/revision-history.yaml
@@ -9,6 +9,7 @@ revisionHistory:
       - Add `fprintf` statement.
       - Add `fflush` statement.
       - Change a cat operation to accept variadic arguments.
+      - Add "enablelayer" modifier to extmodules.
       - Add "knownlayer" modifier to extmodules.
     abi:
      - Remove module name from guard macro for inline layers.

--- a/spec.md
+++ b/spec.md
@@ -293,7 +293,7 @@ circuit Foo :
 
 ### External Modules with Known Layers
 
-Extmodules may be declared with known layers.
+External modules may be declared with known layers.
 A known layer modifier declares that the hardware backing an external module was built with certain (_known_) layers.
 It follows that:
 1. when a layer is enabled for the current circuit, it is also enabled for each external module which "knows" about that layer, and

--- a/spec.md
+++ b/spec.md
@@ -299,7 +299,9 @@ It follows that:
 1. when a layer is enabled for the current circuit, it is also enabled for each external module which "knows" about that layer, and
 2. when a layer is referenced in the interface of an external modules (e.g., in the color of a probe type), that layer must be known.
 
-To declare an extmodule with known layers, use the `knownlayer`{.firrtl} keyword.
+To declare an external module with known layers, use the `knownlayer`{.firrtl} keyword.
+The `knownlayer` keyword may be specified more than once.
+Multiple comma-delimited layers may follow one `knownlayer` keyword.
 The circuit below shows one external module with one layer known:
 
 ``` firrtl

--- a/spec.md
+++ b/spec.md
@@ -302,7 +302,7 @@ To declare an extmodule with known layers, use the `knownlayer`{.firrtl} keyword
 The circuit below shows an extmodule with one layer known:
 
 ```firrtl
-FIRRTL version 5.0.0
+FIRRTL version 5.1.0
 circuit Foo :
   layer A, bind :
   extmodule Bar knownlayer A :

--- a/spec.md
+++ b/spec.md
@@ -4591,7 +4591,7 @@ property_primop_varexpr = property_primop_varexpr_keyword ,
 enablelayer = "enablelayer" , id_path ;
 
 (* Known Layers *)
-knownlayer = "knownlayer" , id_path , { "," id_path };
+knownlayer = "knownlayer" , id_path , { "," id_path } ;
 
 (* Tokens: Annotations *)
 annotations = "%" , "[" , json_array , "]" ;

--- a/spec.md
+++ b/spec.md
@@ -4332,7 +4332,7 @@ decl_module =
   dedent ;
 
 decl_extmodule =
-  "extmodule" , id , ":" , [ info ] , newline , indent ,
+  "extmodule" , id , { enablelayer } , ":" , [ info ] , newline , indent ,
     { port , newline } ,
     [ "defname" , "=" , id , newline ] ,
     { "parameter" , id , "=" , type_param , newline } ,

--- a/spec.md
+++ b/spec.md
@@ -301,7 +301,7 @@ When a layer is referenced in the interface of an extmodule (e.g., in the color 
 To declare an extmodule with known layers, use the `knownlayer`{.firrtl} keyword.
 The circuit below shows an extmodule with one layer known:
 
-```firrtl
+``` firrtl
 FIRRTL version 5.1.0
 circuit Foo :
   layer A, bind :

--- a/spec.md
+++ b/spec.md
@@ -291,6 +291,26 @@ circuit Foo :
   public module Foo enablelayer A :
 ```
 
+### Extmodules with Known Layers
+
+Extmodules may be declared with known layers.
+A known layer modifier declares that the extmodule supports the known layers.
+When a layer is enabled for the current circuit, it is also enabled for each extmodules which "knows" about that layer.
+When a layer is referenced in the interface of an extmodule (e.g., in the color of a probe type), that layer must be known.
+
+To declare an extmodule with known layers, use the `knownlayer`{.firrtl} keyword.
+The circuit below shows an extmodule with one layer known:
+
+```firrtl
+FIRRTL version 5.0.0
+circuit Foo :
+  layer A, bind :
+  extmodule Bar knownlayer A :
+    output probe : Probe<UInt<1>, A>
+  public module Foo :
+    inst bar of Bar
+```
+
 ## Formal Unit Tests
 
 The `formal`{.firrtl} keyword declares a formal unit test.
@@ -4567,6 +4587,9 @@ property_primop_varexpr = property_primop_varexpr_keyword ,
 (* Enable Layers *)
 enablelayer = "enablelayer" , id , { "." , id } ;
 
+(* Known Layers *)
+knownlayer = "knownlayer" , id_path , { "," id_path };
+
 (* Tokens: Annotations *)
 annotations = "%" , "[" , json_array , "]" ;
 
@@ -4601,6 +4624,7 @@ string_dq = '"' , string , '"' ;
 string_sq = "'" , string , "'" ;
 
 (* Tokens: Identifiers *)
+id_path = id , { "." , id } ;
 id = ( "_" | letter ) , { "_" | letter | digit_dec } | literal_id ;
 literal_id = "`" , ( "_" | letter | digit_dec ), { "_" | letter | digit_dec } , "`" ;
 letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"

--- a/spec.md
+++ b/spec.md
@@ -300,7 +300,7 @@ It follows that:
 2. when a layer is referenced in the interface of an external modules (e.g., in the color of a probe type), that layer must be known.
 
 To declare an extmodule with known layers, use the `knownlayer`{.firrtl} keyword.
-The circuit below shows an extmodule with one layer known:
+The circuit below shows one external module with one layer known:
 
 ``` firrtl
 FIRRTL version 5.1.0

--- a/spec.md
+++ b/spec.md
@@ -291,7 +291,7 @@ circuit Foo :
   public module Foo enablelayer A :
 ```
 
-### Extmodules with Known Layers
+### External Modules with Known Layers
 
 Extmodules may be declared with known layers.
 A known layer modifier declares that the hardware backing an external module was built with certain (_known_) layers.

--- a/spec.md
+++ b/spec.md
@@ -4585,7 +4585,7 @@ property_primop_varexpr = property_primop_varexpr_keyword ,
                             "(" , { property_expr } , ")" ;
 
 (* Enable Layers *)
-enablelayer = "enablelayer" , id , { "." , id } ;
+enablelayer = "enablelayer" , id_path ;
 
 (* Known Layers *)
 knownlayer = "knownlayer" , id_path , { "," id_path };

--- a/spec.md
+++ b/spec.md
@@ -4332,7 +4332,7 @@ decl_module =
   dedent ;
 
 decl_extmodule =
-  "extmodule" , id , { enablelayer } , ":" , [ info ] , newline , indent ,
+  "extmodule" , id , { enablelayer | knownlayer } , ":" , [ info ] , newline , indent ,
     { port , newline } ,
     [ "defname" , "=" , id , newline ] ,
     { "parameter" , id , "=" , type_param , newline } ,

--- a/spec.md
+++ b/spec.md
@@ -294,7 +294,7 @@ circuit Foo :
 ### External Modules with Known Layers
 
 External modules may be declared with known layers.
-A known layer modifier declares that the hardware backing an external module was built with certain (_known_) layers.
+A known layer modifier declares that the hardware backing an external module was built with certain (*known*) layers.
 It follows that:
 1. when a layer is enabled for the current circuit, it is also enabled for each external module which "knows" about that layer, and
 2. when a layer is referenced in the interface of an external modules (e.g., in the color of a probe type), that layer must be known.

--- a/spec.md
+++ b/spec.md
@@ -294,9 +294,10 @@ circuit Foo :
 ### Extmodules with Known Layers
 
 Extmodules may be declared with known layers.
-A known layer modifier declares that the extmodule supports the known layers.
-When a layer is enabled for the current circuit, it is also enabled for each extmodules which "knows" about that layer.
-When a layer is referenced in the interface of an extmodule (e.g., in the color of a probe type), that layer must be known.
+A known layer modifier declares that the hardware backing an external module was built with certain (_known_) layers.
+It follows that:
+1. when a layer is enabled for the current circuit, it is also enabled for each external module which "knows" about that layer, and
+2. when a layer is referenced in the interface of an external modules (e.g., in the color of a probe type), that layer must be known.
 
 To declare an extmodule with known layers, use the `knownlayer`{.firrtl} keyword.
 The circuit below shows an extmodule with one layer known:


### PR DESCRIPTION
Knownlayer declarations are specified on an extmodule to declare that the extmodule supports the mentioned layers. When a layer is enabled, it should also be enabled for extmodules, when the extmodule knows about the layer.
