### PR TITLE
[nfc] Update README.md with more dependency info

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,19 @@ To build this, you need the following:
 - [`latexmk`](https://ctan.org/pkg/latexmk?lang=en) which may come with your LaTeX distribution
 - [Graphviz](https://graphviz.org/)
 
-For compatibility with continuous integration (CI) testing, use the versions of
-`pandoc` and `pandoc-crossref` that are [listed in the CI GitHub
+For compatibility with continuous integration (CI) formatting, use the versions
+of `pandoc` and `pandoc-crossref` that are [listed in the CI GitHub
 Action](.github/workflows/continuous-integration-ci.yml). If this release is
 *not* available in your package manager, you can download binaries from their
 GitHub releases pages:
 - [`pandoc` releases](https://github.com/jgm/pandoc/releases)
 - [`pandoc-crossref` releases](https://github.com/lierdakil/pandoc-crossref/releases)
 
-To run tests, you need Verilator and `firtool` available on your `PATH`.
+To run tests, both `firtool` and Verilator must be available on your `PATH`.
+For compatibility with CI testing, use the version of `firtool` specified in
+[include/circt.json](include/circt.json) and the Verilator version used by the
+version of the OSS CAD Suite in [listed in the CI GitHub
+Action](.github/workflows/continuous-integration-ci.yml).
 
 After resolving these dependencies, use the following build targets:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To build this, you need the following:
 - [`latexmk`](https://ctan.org/pkg/latexmk?lang=en) which may come with your LaTeX distribution
 - [Graphviz](https://graphviz.org/)
 
-For compatability with continuous integration (CI) testing, use the versions of
+For compatibility with continuous integration (CI) testing, use the versions of
 `pandoc` and `pandoc-crossref` that are [listed in the CI GitHub
 Action](.github/workflows/continuous-integration-ci.yml). If this release is
 *not* available in your package manager, you can download binaries from their

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ GitHub releases pages:
 - [`pandoc` releases](https://github.com/jgm/pandoc/releases)
 - [`pandoc-crossref` releases](https://github.com/lierdakil/pandoc-crossref/releases)
 
-To run tests, you need Verilator and `firtool` available on your `$PATH`.
+To run tests, you need Verilator and `firtool` available on your `PATH`.
 
 After resolving these dependencies, use the following build targets:
 

--- a/README.md
+++ b/README.md
@@ -8,4 +8,23 @@ To build this, you need the following:
 - [`latexmk`](https://ctan.org/pkg/latexmk?lang=en) which may come with your LaTeX distribution
 - [Graphviz](https://graphviz.org/)
 
-After resolving these dependencies, run `make` to compile `spec.md` into `build/spec.pdf`.
+For compatability with continuous integration (CI) testing, use the versions of
+`pandoc` and `pandoc-crossref` that are [listed in the CI GitHub
+Action](.github/workflows/continuous-integration-ci.yml). If this release is
+*not* available in your package manager, you can download binaries from their
+GitHub releases pages:
+- [`pandoc` releases](https://github.com/jgm/pandoc/releases)
+- [`pandoc-crossref` releases](https://github.com/lierdakil/pandoc-crossref/releases)
+
+To run tests, you need Verilator and `firtool` available on your `$PATH`.
+
+After resolving these dependencies, use the following build targets:
+
+- `make` or `make all` will compile will compile `spec.md` and `abi.md` into
+  `build/spec.pdf` and `build/abi.pdf`.
+- `make format` will format all Markdown files by round-tripping them through
+  `pandoc`. *For this build step to be usable, use the exact versions of
+  `pandoc` and `pandoc-crossref` that CI uses!*
+- `make test` will extract FIRRTL and Verilog snippets from the specification
+  and ABI document and, respectively, run them through `firtool -parse-only` or
+  `verilator --lint-only` to test that they are legal FIRRTL or Verilog.


### PR DESCRIPTION
Update the README.md to add much more information about what the
dependencies are, how to get them, and what the available build targets
are.

This is intended to alleviate concerns expressed in #318 about users
having difficulty running `make format` because their installation of
`pandoc` is incorrect relative to what is being tested in CI.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>
